### PR TITLE
Refresh dashboard and fusion UI

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -7,39 +7,80 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
-  <h1>🧭 AICraft Cluster Dashboard</h1>
+  <header>
+    <div class="title-row">
+      <h1>🧭 AICraft Cluster Dashboard</h1>
+      <a class="fusion-breadcrumb" href="fusion.html">Fusion Memory &rsaquo;</a>
+    </div>
+    <p>Monitor the health, performance, and coordination of the AICraft collective. Tune policies, inspect fusion knowledge, and spot anomalies across the cluster at a glance.</p>
+  </header>
 
-  <div id="cluster-grid"></div>
+  <div class="dashboard-layout">
+    <main class="main-content">
+      <section class="card">
+        <h2>🌐 Cluster Nodes</h2>
+        <p class="section-subtitle">Live topology of connected cognitive nodes, updated in real time.</p>
+        <div id="cluster-grid"></div>
+      </section>
 
-  <section id="charts">
-    <h2>📈 Cluster Analytics</h2>
-    <canvas id="cpuChart"></canvas>
-    <canvas id="memChart"></canvas>
-  </section>
+      <section id="charts" class="card">
+        <div>
+          <h2>📈 CPU Utilization</h2>
+          <p class="section-subtitle">Rolling 15 minute window of aggregate CPU consumption.</p>
+          <canvas id="cpuChart"></canvas>
+        </div>
+        <div>
+          <h2>💾 Memory Allocation</h2>
+          <p class="section-subtitle">Active memory footprint per cluster node.</p>
+          <canvas id="memChart"></canvas>
+        </div>
+      </section>
 
-  <section id="fusion-sidebar">
-    <h2>🧠 Fusion Knowledge Summary</h2>
-    <ul>
-      <li><b>NPC Skills:</b> <span id="fusion-skills">0</span></li>
-      <li><b>Dialogues:</b> <span id="fusion-dialogues">0</span></li>
-      <li><b>Outcomes:</b> <span id="fusion-outcomes">0</span></li>
-      <li><b>Last Sync:</b> <span id="fusion-last">N/A</span></li>
-    </ul>
-    <canvas id="fusionBar" width="200" height="120"></canvas>
-    <a href="fusion.html" id="view-fusion">🔍 View Memory Details</a>
-  </section>
+      <section id="policy-panel" class="card">
+        <h2>⚙️ Policy Control Panel</h2>
+        <p class="section-subtitle">Adjust learning heuristics to steer delegation, training cadence, and adaptation.</p>
+        <label>Learning Rate <span id="lr-value">1.0</span></label>
+        <input type="range" id="learningRate" min="0.1" max="2" step="0.1" value="1.0">
+        <label>Delegation Bias <span id="db-value">0.4</span></label>
+        <input type="range" id="delegationBias" min="0" max="1" step="0.05" value="0.4">
+        <label>Cooldown (ms) <span id="cd-value">10000</span></label>
+        <input type="range" id="cooldown" min="1000" max="30000" step="1000" value="10000">
+        <button id="apply-policy">Apply Policy</button>
+      </section>
+    </main>
 
-  <section id="policy-panel">
-    <h2>⚙️ Policy Control Panel</h2>
-    <label>Learning Rate: <span id="lr-value">1.0</span></label>
-    <input type="range" id="learningRate" min="0.1" max="2" step="0.1" value="1.0">
-    <label>Delegation Bias: <span id="db-value">0.4</span></label>
-    <input type="range" id="delegationBias" min="0" max="1" step="0.05" value="0.4">
-    <label>Cooldown (ms): <span id="cd-value">10000</span></label>
-    <input type="range" id="cooldown" min="1000" max="30000" step="1000" value="10000">
-    <button id="apply-policy">Apply Policy</button>
-  </section>
+    <aside id="fusion-sidebar">
+      <h2>🧠 Fusion Knowledge Summary</h2>
+      <div class="fusion-stats">
+        <div class="stat">
+          <small>NPC Skills</small>
+          <span id="fusion-skills">0</span>
+        </div>
+        <div class="stat">
+          <small>Dialogues</small>
+          <span id="fusion-dialogues">0</span>
+        </div>
+        <div class="stat">
+          <small>Outcomes</small>
+          <span id="fusion-outcomes">0</span>
+        </div>
+        <div class="stat">
+          <small>Last Sync</small>
+          <span id="fusion-last" class="badge-warning">N/A</span>
+        </div>
+      </div>
+      <canvas id="fusionBar" width="200" height="120"></canvas>
+      <a href="fusion.html" id="view-fusion">🔍 View Memory Details</a>
+    </aside>
+  </div>
 
+  <footer>
+    &copy; <span id="year"></span> AICraft Cluster Intelligence Network
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
   <script src="dashboard.js"></script>
 </body>
 </html>

--- a/fusion.html
+++ b/fusion.html
@@ -7,12 +7,53 @@
   <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
 </head>
 <body>
-  <h1>🧠 Fusion Memory Overview</h1>
-  <div id="fusion-details">
-    <canvas id="fusionPie"></canvas>
+  <header>
+    <div class="title-row">
+      <h1>🧠 Fusion Memory Overview</h1>
+      <a class="fusion-breadcrumb" href="dashboard.html">&lsaquo; Cluster Dashboard</a>
+    </div>
+    <p>Explore the aggregated knowledge distilled from NPC learning. Inspect proportions of skills, dialogues, and mission outcomes.</p>
+  </header>
+
+  <section class="card">
+    <h2>Knowledge Composition</h2>
+    <p class="section-subtitle">Distribution of memory artifacts synchronized across the collective.</p>
+    <div id="fusion-details">
+      <canvas id="fusionPie"></canvas>
+      <div class="fusion-stats">
+        <div class="stat">
+          <small>NPC Skills</small>
+          <span id="fusion-skills-detail">0</span>
+        </div>
+        <div class="stat">
+          <small>Dialogues</small>
+          <span id="fusion-dialogues-detail">0</span>
+        </div>
+        <div class="stat">
+          <small>Outcomes</small>
+          <span id="fusion-outcomes-detail">0</span>
+        </div>
+        <div class="stat">
+          <small>Last Sync</small>
+          <span id="fusion-last-detail" class="badge-warning">N/A</span>
+        </div>
+      </div>
+    </div>
+  </section>
+
+  <section class="card">
+    <h2>Raw Fusion Payload</h2>
+    <p class="section-subtitle">Full JSON payload for debugging and deep dives.</p>
     <pre id="fusionData">Loading fusion data...</pre>
-  </div>
-  <a href="dashboard.html">⬅ Back to Dashboard</a>
+  </section>
+
+  <footer>
+    &copy; <span id="year"></span> AICraft Cluster Intelligence Network
+  </footer>
+
+  <script>
+    document.getElementById('year').textContent = new Date().getFullYear();
+  </script>
   <script src="fusion.js"></script>
 </body>
 </html>

--- a/fusion.js
+++ b/fusion.js
@@ -25,13 +25,39 @@ function render(data) {
           Object.keys(data.dialogues || {}).length,
           (data.outcomes || []).length
         ],
-        backgroundColor: ["#58a6ff", "#3fb950", "#f85149"]
+        backgroundColor: ["#60a5fa", "#34d399", "#f87171"],
+        borderWidth: 2,
+        borderColor: "rgba(15, 23, 42, 0.85)",
+        hoverOffset: 10
       }]
     },
     options: { plugins: { legend: { position: "bottom" } } }
   });
 
   document.getElementById("fusionData").textContent = JSON.stringify(data, null, 2);
+
+  const skills = Object.keys(data.skills || {}).length;
+  const dialogues = Object.keys(data.dialogues || {}).length;
+  const outcomes = (data.outcomes || []).length;
+  const lastSync = data.lastSync || "N/A";
+
+  const map = [
+    ["fusion-skills", skills],
+    ["fusion-dialogues", dialogues],
+    ["fusion-outcomes", outcomes],
+    ["fusion-last", lastSync],
+    ["fusion-skills-detail", skills],
+    ["fusion-dialogues-detail", dialogues],
+    ["fusion-outcomes-detail", outcomes],
+    ["fusion-last-detail", lastSync]
+  ];
+
+  map.forEach(([id, value]) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.textContent = value;
+    }
+  });
 }
 
 loadFusionData();

--- a/style.css
+++ b/style.css
@@ -1,19 +1,322 @@
-body { background: #0d1117; color: #c9d1d9; font-family: 'Segoe UI', sans-serif; padding: 20px; }
-h1 { color: #58a6ff; }
-#cluster-grid { display: flex; flex-wrap: wrap; gap: 20px; margin-top: 20px; }
-.node-card { background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 15px; width: 220px; transition: transform 0.2s; }
-.node-card:hover { transform: scale(1.05); }
-.ok { color: #3fb950; font-weight: bold; }
-.bad { color: #f85149; font-weight: bold; }
-#charts, #policy-panel { background: #161b22; margin-top: 40px; padding: 20px; border-radius: 8px; }
-canvas { margin-top: 25px; background: #0d1117; border-radius: 6px; padding: 10px; }
-#fusion-sidebar { position: fixed; top: 20px; right: 20px; width: 240px; background: #161b22; border: 1px solid #30363d; border-radius: 8px; padding: 15px; }
-#fusion-sidebar h2 { color: #58a6ff; }
-#fusion-sidebar canvas { margin-top: 10px; }
-#view-fusion { display: block; margin-top: 12px; text-align: center; color: #58a6ff; text-decoration: none; }
-#view-fusion:hover { text-decoration: underline; }
-@keyframes pulseGlow { 0% { box-shadow: 0 0 0px #58a6ff; } 50% { box-shadow: 0 0 15px #58a6ff; } 100% { box-shadow: 0 0 0px #58a6ff; } }
-.fusion-pulse { animation: pulseGlow 1.2s ease-in-out; }
+:root {
+  --bg-gradient: radial-gradient(circle at top left, #1f2937, #0b1120 55%, #050810 100%);
+  --card-bg: rgba(17, 24, 39, 0.92);
+  --card-border: rgba(148, 163, 184, 0.12);
+  --accent: #60a5fa;
+  --accent-soft: rgba(96, 165, 250, 0.2);
+  --text-primary: #e2e8f0;
+  --text-secondary: #94a3b8;
+  --success: #34d399;
+  --danger: #f87171;
+  --warning: #fbbf24;
+  --font-display: "Inter", "Segoe UI", sans-serif;
+}
 
-#fusion-details { display: flex; flex-direction: column; gap: 20px; max-width: 640px; }
-#fusion-details pre { background: #161b22; padding: 16px; border-radius: 8px; overflow-x: auto; }
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  min-height: 100vh;
+  background: var(--bg-gradient);
+  color: var(--text-primary);
+  font-family: var(--font-display);
+  padding: 32px clamp(16px, 4vw, 64px);
+  display: flex;
+  flex-direction: column;
+  gap: 32px;
+}
+
+a {
+  color: inherit;
+}
+
+h1,
+ h2,
+ h3 {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.section-subtitle {
+  margin-top: 6px;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+header {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+header .title-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+header p {
+  color: var(--text-secondary);
+  max-width: 720px;
+}
+
+#cluster-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 20px;
+}
+
+section,
+.card {
+  background: var(--card-bg);
+  border: 1px solid var(--card-border);
+  border-radius: 16px;
+  padding: 24px;
+  backdrop-filter: blur(14px);
+  box-shadow: 0 24px 48px -32px rgba(15, 23, 42, 0.8);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+section:hover,
+.card:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 32px 60px -40px rgba(15, 23, 42, 0.9);
+}
+
+.node-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  background: linear-gradient(160deg, rgba(17, 24, 39, 0.96), rgba(10, 12, 20, 0.9));
+  border: 1px solid rgba(96, 165, 250, 0.12);
+  border-radius: 18px;
+  padding: 20px;
+}
+
+.node-card .status-badge {
+  align-self: flex-start;
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  background: rgba(148, 163, 184, 0.12);
+}
+
+.node-card .status-badge.ok {
+  color: var(--success);
+  background: rgba(52, 211, 153, 0.12);
+}
+
+.node-card .status-badge.bad {
+  color: var(--danger);
+  background: rgba(248, 113, 113, 0.12);
+}
+
+.node-card strong {
+  color: var(--accent);
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 20px;
+}
+
+.metric-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  border: 1px solid rgba(96, 165, 250, 0.12);
+  background: linear-gradient(200deg, rgba(96, 165, 250, 0.12), rgba(15, 23, 42, 0.2));
+}
+
+.metric-card span {
+  font-size: 32px;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+}
+
+.metric-card small {
+  color: var(--text-secondary);
+  font-size: 13px;
+}
+
+#charts {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 24px;
+}
+
+canvas {
+  margin-top: 12px;
+  background: rgba(15, 23, 42, 0.72);
+  border-radius: 12px;
+  padding: 14px;
+  border: 1px solid rgba(96, 165, 250, 0.1);
+}
+
+#policy-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+#policy-panel label {
+  display: flex;
+  justify-content: space-between;
+  font-size: 14px;
+  color: var(--text-secondary);
+}
+
+#policy-panel input[type="range"] {
+  accent-color: var(--accent);
+  width: 100%;
+}
+
+button {
+  align-self: flex-start;
+  border: none;
+  padding: 12px 20px;
+  border-radius: 12px;
+  background: linear-gradient(120deg, var(--accent), #2563eb);
+  color: #0b1120;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  box-shadow: 0 10px 20px -12px rgba(37, 99, 235, 0.8);
+}
+
+button:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 16px 28px -16px rgba(37, 99, 235, 0.9);
+}
+
+#fusion-sidebar {
+  position: sticky;
+  top: 32px;
+  align-self: flex-start;
+  width: min(280px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  border: 1px solid rgba(248, 250, 252, 0.06);
+}
+
+#fusion-sidebar ul {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  color: var(--text-secondary);
+  font-size: 14px;
+}
+
+#fusion-sidebar li b {
+  color: var(--text-primary);
+}
+
+#fusion-sidebar canvas {
+  margin-top: 0;
+  max-height: 150px;
+}
+
+#view-fusion {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 10px 16px;
+  border-radius: 10px;
+  background: rgba(96, 165, 250, 0.14);
+  color: var(--accent);
+  text-decoration: none;
+  font-weight: 500;
+  transition: background 0.2s ease;
+}
+
+#view-fusion:hover {
+  background: rgba(96, 165, 250, 0.22);
+}
+
+.dashboard-layout {
+  display: grid;
+  gap: 24px;
+  align-items: start;
+}
+
+.main-content {
+  display: grid;
+  gap: 24px;
+}
+
+@media (min-width: 1100px) {
+  .dashboard-layout {
+    grid-template-columns: minmax(0, 1fr) 320px;
+  }
+}
+
+.fusion-breadcrumb {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-secondary);
+  font-size: 14px;
+  margin-top: -12px;
+}
+
+#fusion-details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 24px;
+  align-items: start;
+}
+
+#fusion-details pre {
+  background: rgba(15, 23, 42, 0.74);
+  padding: 20px;
+  border-radius: 14px;
+  border: 1px solid rgba(96, 165, 250, 0.1);
+  color: var(--text-secondary);
+  font-size: 13px;
+  line-height: 1.6;
+  box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.04);
+}
+
+.fusion-stats {
+  display: grid;
+  gap: 16px;
+}
+
+.fusion-stats .stat {
+  padding: 16px;
+  border-radius: 12px;
+  border: 1px solid rgba(96, 165, 250, 0.16);
+  background: linear-gradient(160deg, rgba(96, 165, 250, 0.16), rgba(15, 23, 42, 0.2));
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.fusion-stats .stat span {
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--accent);
+}
+
+.badge-warning {
+  color: var(--warning);
+}
+
+footer {
+  margin-top: auto;
+  color: var(--text-secondary);
+  font-size: 13px;
+  text-align: center;
+}


### PR DESCRIPTION
## Summary
- redesign the dashboard layout with hero header, card-based sections, and sticky fusion summary
- refresh fusion detail view with richer stats cards and responsive composition layout
- expand shared styling with gradients, typography tweaks, and polished controls

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f43f0e9c3c832da07c5e8a51641ed9