### PR TITLE
Enhance gather and mine planners with readiness checks

### DIFF
--- a/task_broker.js
+++ b/task_broker.js
@@ -3,6 +3,7 @@
 
 import { CognitiveLink } from "./cognitive_link.js";
 import { validateTask } from "./task_schema.js";
+import { planTask } from "./tasks/index.js";
 import fs from "fs/promises";
 import fsSync from "fs";
 import EventEmitter from "events";
@@ -169,8 +170,14 @@ export class TaskBroker extends EventEmitter {
 
   async executeLocally(task) {
     console.log(`🏠 Executing locally: ${task.action}`);
-    this.emit("local_execution", task);
-    return { result: `Task "${task.action}" executed locally`, from: this.manifest.nodeName, local: true };
+    const plan = planTask(task);
+    this.emit("local_execution", { task, plan });
+
+    const result = plan
+      ? { summary: plan.summary, plan }
+      : { summary: `Task "${task.action}" executed locally` };
+
+    return { result, from: this.manifest.nodeName, local: true };
   }
 
   getStatus() {

--- a/tasks/helpers.js
+++ b/tasks/helpers.js
@@ -1,0 +1,155 @@
+// tasks/helpers.js
+// Shared helper utilities for task planning modules
+
+function isFiniteNumber(value) {
+  return typeof value === "number" && Number.isFinite(value);
+}
+
+export function describeTarget(target) {
+  if (!target) {
+    return "current position";
+  }
+
+  if (typeof target === "string") {
+    return target;
+  }
+
+  if (typeof target !== "object") {
+    return "target location";
+  }
+
+  const { name, label, dimension } = target;
+  const coords = [target.x, target.y, target.z]
+    .map(value => (isFiniteNumber(value) ? value.toFixed(1) : null))
+    .filter(value => value !== null);
+
+  const parts = [];
+  if (name || label) {
+    parts.push(name || label);
+  }
+  if (coords.length === 3) {
+    parts.push(`(${coords.join(", ")})`);
+  }
+  if (dimension) {
+    parts.push(dimension);
+  }
+
+  return parts.length > 0 ? parts.join(" ") : "target location";
+}
+
+export function normalizeItemName(item) {
+  if (!item || typeof item !== "string") {
+    return "unspecified item";
+  }
+  return item
+    .replace(/[_-]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+    .toLowerCase();
+}
+
+export function resolveQuantity(value, fallback = null) {
+  if (isFiniteNumber(value)) {
+    return value;
+  }
+  if (typeof value === "string") {
+    const parsed = Number.parseInt(value, 10);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  }
+  return fallback;
+}
+
+export function createPlan({
+  task,
+  summary,
+  steps,
+  estimatedDuration = 8000,
+  resources = [],
+  risks = [],
+  notes = []
+}) {
+  return {
+    action: task.action,
+    summary,
+    estimatedDuration,
+    resources,
+    steps: Array.isArray(steps) ? steps : [],
+    risks: Array.isArray(risks) ? risks : [],
+    notes: Array.isArray(notes) ? notes : []
+  };
+}
+
+export function createStep({ title, description, command = null, type = "generic", metadata = {} }) {
+  return {
+    title,
+    description,
+    command,
+    type,
+    metadata
+  };
+}
+
+export function extractInventory(context = {}) {
+  const rawInventory = context.inventory || context?.npc?.inventory || [];
+  if (!Array.isArray(rawInventory)) {
+    return [];
+  }
+
+  return rawInventory
+    .map(entry => {
+      if (entry && typeof entry === "object") {
+        const name = normalizeItemName(entry.name || entry.item || entry.id || entry.type);
+        const count = resolveQuantity(entry.count ?? entry.quantity ?? entry.amount, 1);
+        return { name, count: count ?? 1 };
+      }
+      if (typeof entry === "string") {
+        return { name: normalizeItemName(entry), count: 1 };
+      }
+      return null;
+    })
+    .filter(Boolean);
+}
+
+export function countInventoryItems(inventory, itemName) {
+  if (!Array.isArray(inventory) || !itemName) {
+    return 0;
+  }
+  const normalized = normalizeItemName(itemName);
+  return inventory.reduce((total, entry) => {
+    if (entry?.name === normalized) {
+      return total + (entry.count ?? 0);
+    }
+    return total;
+  }, 0);
+}
+
+export function hasInventoryItem(inventory, itemName, count = 1) {
+  if (!Array.isArray(inventory) || !itemName) {
+    return false;
+  }
+  const required = resolveQuantity(count, 1) ?? 1;
+  if (required <= 0) {
+    return true;
+  }
+  return countInventoryItems(inventory, itemName) >= required;
+}
+
+export function formatRequirementList(requirements = []) {
+  if (!Array.isArray(requirements) || requirements.length === 0) {
+    return "";
+  }
+
+  return requirements
+    .map(req => {
+      const name = normalizeItemName(req?.name || req?.item || req);
+      const count = resolveQuantity(req?.count ?? req?.quantity, null);
+      if (count && count > 0) {
+        return `${count} ${name}`;
+      }
+      return name;
+    })
+    .filter(Boolean)
+    .join(", ");
+}

--- a/tasks/index.js
+++ b/tasks/index.js
@@ -1,0 +1,66 @@
+// tasks/index.js
+// Central registry and planning utilities for Minecraft NPC tasks
+
+import { planBuildTask } from "./plan_build.js";
+import { planMineTask } from "./plan_mine.js";
+import { planExploreTask } from "./plan_explore.js";
+import { planGatherTask } from "./plan_gather.js";
+import { planGuardTask } from "./plan_guard.js";
+import { planCraftTask } from "./plan_craft.js";
+import { planInteractTask } from "./plan_interact.js";
+import { planCombatTask } from "./plan_combat.js";
+
+import {
+  describeTarget,
+  normalizeItemName,
+  createPlan,
+  createStep,
+  resolveQuantity,
+  extractInventory,
+  hasInventoryItem,
+  countInventoryItems,
+  formatRequirementList
+} from "./helpers.js";
+
+export {
+  describeTarget,
+  normalizeItemName,
+  createPlan,
+  createStep,
+  resolveQuantity,
+  extractInventory,
+  hasInventoryItem,
+  countInventoryItems,
+  formatRequirementList
+} from "./helpers.js";
+
+const TASK_PLANNERS = {
+  build: planBuildTask,
+  mine: planMineTask,
+  explore: planExploreTask,
+  gather: planGatherTask,
+  guard: planGuardTask,
+  craft: planCraftTask,
+  interact: planInteractTask,
+  combat: planCombatTask
+};
+
+export function planTask(task, context = {}) {
+  if (!task || typeof task !== "object") {
+    return null;
+  }
+  const planner = TASK_PLANNERS[task.action];
+  if (!planner) {
+    return null;
+  }
+  try {
+    return planner(task, context) || null;
+  } catch (err) {
+    console.error(`❌ Failed to plan task for action "${task.action}":`, err.message);
+    return null;
+  }
+}
+
+export function hasPlanner(action) {
+  return Boolean(TASK_PLANNERS[action]);
+}

--- a/tasks/plan_build.js
+++ b/tasks/plan_build.js
@@ -1,0 +1,355 @@
+// tasks/plan_build.js
+// Planning logic for construction tasks
+
+import {
+  createPlan,
+  createStep,
+  describeTarget,
+  normalizeItemName,
+  extractInventory,
+  hasInventoryItem,
+  formatRequirementList,
+  resolveQuantity
+} from "./helpers.js";
+
+function parseDimensions(metadata = {}) {
+  const raw = metadata.dimensions || metadata.dimension || "";
+  if (typeof raw === "string" && raw.includes("x")) {
+    const parts = raw
+      .split("x")
+      .map(part => Number.parseInt(part.trim(), 10))
+      .filter(num => Number.isFinite(num) && num > 0);
+    if (parts.length === 3) {
+      return { length: parts[0], width: parts[1], height: parts[2] };
+    }
+    if (parts.length === 2) {
+      return {
+        length: parts[0],
+        width: parts[1],
+        height: metadata.height ? resolveQuantity(metadata.height, null) : null
+      };
+    }
+  }
+
+  const length = resolveQuantity(metadata.length, null);
+  const width = resolveQuantity(metadata.width, null);
+  const height = resolveQuantity(metadata.height ?? metadata.floors, null);
+  if (length && width) {
+    return { length, width, height };
+  }
+  return null;
+}
+
+function normalizeMaterials(task) {
+  const explicit = Array.isArray(task?.metadata?.materials) ? task?.metadata?.materials : [];
+  const quantities = task?.metadata?.materialQuantities || task?.metadata?.materialCounts || {};
+  const normalized = explicit
+    .map(entry => {
+      if (typeof entry === "string") {
+        return {
+          name: normalizeItemName(entry),
+          count: resolveQuantity(quantities[entry], null)
+        };
+      }
+      if (entry && typeof entry === "object") {
+        const name = normalizeItemName(entry.name || entry.item);
+        const count = resolveQuantity(entry.count ?? entry.quantity, null);
+        return { name, count };
+      }
+      return null;
+    })
+    .filter(Boolean);
+
+  if (normalized.length > 0) {
+    return normalized;
+  }
+
+  const fallback = normalizeItemName(task?.metadata?.primaryMaterial || task?.details || "building blocks");
+  const fallbackCount = resolveQuantity(task?.metadata?.quantity ?? task?.metadata?.blocks, null);
+  return [{ name: fallback, count: fallbackCount }];
+}
+
+export function planBuildTask(task, context = {}) {
+  const blueprint = normalizeItemName(task?.metadata?.blueprint || task?.metadata?.structure || task.details);
+  const targetDescription = describeTarget(task.target);
+  const orientation = normalizeItemName(task?.metadata?.orientation || task?.metadata?.facing || "");
+  const height = resolveQuantity(task?.metadata?.height ?? task?.metadata?.floors, null);
+  const inventory = extractInventory(context);
+  const dimensions = parseDimensions(task?.metadata);
+
+  const floorArea = dimensions?.length && dimensions?.width ? dimensions.length * dimensions.width : null;
+  const enclosedVolume = floorArea && (dimensions?.height || height)
+    ? floorArea * (dimensions.height || height)
+    : null;
+
+  const materialRequirements = normalizeMaterials(task);
+  const missingMaterials = materialRequirements.filter(req => {
+    if (!req?.name || req.name === "unspecified item") {
+      return false;
+    }
+    if (req.count && req.count > 0) {
+      return !hasInventoryItem(inventory, req.name, req.count);
+    }
+    return !hasInventoryItem(inventory, req.name, 1);
+  });
+
+  const materialSummary = formatRequirementList(materialRequirements);
+  const missingSummary = formatRequirementList(missingMaterials);
+  const blockCount = materialRequirements.reduce((total, req) => {
+    const count = resolveQuantity(req.count, 0);
+    return total + (count || 0);
+  }, 0);
+
+  const toolChecklist = [];
+  const addTool = tool => {
+    const normalized = normalizeItemName(tool);
+    if (!normalized || normalized === "unspecified item") {
+      return;
+    }
+    if (!toolChecklist.includes(normalized)) {
+      toolChecklist.push(normalized);
+    }
+  };
+
+  if (height && height > 6) {
+    addTool("scaffolding");
+  }
+  if (task?.metadata?.terrain === "rocky" || task?.metadata?.foundation === "stone") {
+    addTool("pickaxe");
+  }
+  if (task?.metadata?.terrain === "forest" || task?.metadata?.clearTrees) {
+    addTool("axe");
+  }
+  if (task?.metadata?.terrain === "sand" || task?.metadata?.levelGround) {
+    addTool("shovel");
+  }
+  if (task?.metadata?.includesRedstone) {
+    addTool("redstone toolkit");
+  }
+  if (task?.metadata?.lighting || task?.metadata?.buildAtNight) {
+    addTool("torches");
+  }
+
+  const missingTools = toolChecklist.filter(tool => !hasInventoryItem(inventory, tool, 1));
+
+  const steps = [];
+
+  if (toolChecklist.length > 0) {
+    const toolDescription = missingTools.length
+      ? `Gather tools before departure: ${formatRequirementList(missingTools.map(name => ({ name })))}.`
+      : `Confirm required tools are on hand: ${formatRequirementList(toolChecklist.map(name => ({ name })))}.`;
+    steps.push(
+      createStep({
+        title: missingTools.length > 0 ? "Prepare tools" : "Verify tools",
+        type: "inventory",
+        description: toolDescription,
+        metadata: { required: toolChecklist, missing: missingTools }
+      })
+    );
+  }
+
+  if (task?.metadata?.blueprintUrl || task?.metadata?.blueprintReference) {
+    const reference =
+      task?.metadata?.blueprintReference || task?.metadata?.blueprintUrl || blueprint || "structure";
+    steps.push(
+      createStep({
+        title: "Review blueprint",
+        type: "planning",
+        description: `Load ${reference} and verify dimensions before construction begins.`
+      })
+    );
+  }
+
+  const verifyDescription = materialSummary
+    ? `Confirm required materials are ready: ${materialSummary}.`
+    : "Confirm required materials are ready for the build.";
+  const restockDescription = missingSummary
+    ? `Obtain missing resources: ${missingSummary}. Stage extras near the build site.`
+    : "Obtain missing resources before heading to the site.";
+
+  steps.push(
+    createStep({
+      title: missingMaterials.length > 0 ? "Restock materials" : "Verify materials",
+      type: "inventory",
+      description: missingMaterials.length > 0 ? restockDescription : verifyDescription,
+      metadata: { materials: materialRequirements, missing: missingMaterials }
+    })
+  );
+
+  const surveyDescription = orientation
+    ? `Inspect ${targetDescription} to ensure the area is clear, mark foundation corners, and align the main entrance toward ${orientation}.`
+    : `Inspect ${targetDescription} to ensure the area is clear for building and mark foundation corners.`;
+
+  steps.push(
+    createStep({
+      title: "Survey site",
+      type: "planning",
+      description: surveyDescription
+    })
+  );
+
+  if (task?.metadata?.terrain === "uneven" || task?.metadata?.levelGround) {
+    steps.push(
+      createStep({
+        title: "Prepare terrain",
+        type: "preparation",
+        description: `Clear vegetation and level ground to support the ${blueprint} footprint.`
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Stage materials",
+      type: "collection",
+      description: `Move materials on-site, placing staging chests or shulker boxes for ${blueprint}.`,
+      metadata: { materials: materialRequirements }
+    })
+  );
+
+  if (task?.metadata?.perimeter || task?.metadata?.threatLevel === "high") {
+    steps.push(
+      createStep({
+        title: "Secure perimeter",
+        type: "safety",
+        description: "Place perimeter lighting and temporary barricades to prevent mob interference during construction.",
+        metadata: { recommended: ["torches", "fences"] }
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Lay foundation",
+      type: "construction",
+      description: `Outline the ${blueprint} footprint and reinforce the base with durable blocks.`
+    })
+  );
+
+  if (height && height > 6) {
+    steps.push(
+      createStep({
+        title: "Place scaffolding",
+        type: "safety",
+        description: `Set up scaffolding and guard rails to safely build up to ${height} blocks high.`
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Assemble structure",
+      type: "construction",
+      description: `Build the ${blueprint} layer by layer, checking alignment with the blueprint after each level.`
+    })
+  );
+
+  if (task?.metadata?.roofStyle || task?.metadata?.requiresRoof) {
+    steps.push(
+      createStep({
+        title: "Install roof",
+        type: "construction",
+        description: `Shape the roof using the ${task?.metadata?.roofStyle || "specified"} style, ensuring overhangs and lighting prevent mob spawns.`
+      })
+    );
+  }
+
+  if (task?.metadata?.includesRedstone) {
+    steps.push(
+      createStep({
+        title: "Install redstone",
+        type: "automation",
+        description: `Wire redstone components and test circuits before sealing access panels.`
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Finish and inspect",
+      type: "inspection",
+      description: `Add lighting, doors, and final touches, then verify the structure matches the blueprint and meets safety checks.`
+    })
+  );
+
+  if (task?.metadata?.interior !== false) {
+    steps.push(
+      createStep({
+        title: "Outfit interior",
+        type: "decoration",
+        description: "Place furnishings, storage, and lighting, verifying accessibility and spawn-proofing inside the structure."
+      })
+    );
+  }
+
+  if (task?.metadata?.cleanup !== false) {
+    steps.push(
+      createStep({
+        title: "Cleanup site",
+        type: "cleanup",
+        description: `Remove scaffolding, excess materials, and restore surrounding terrain.`
+      })
+    );
+  }
+
+  const resources = [
+    ...new Set(
+      materialRequirements
+        .map(req => req.name)
+        .filter(name => name && name !== "unspecified item")
+    )
+  ];
+  if (toolChecklist.length > 0) {
+    for (const tool of toolChecklist) {
+      if (!resources.includes(tool)) {
+        resources.push(tool);
+      }
+    }
+  }
+  const risks = [];
+  if (height && height > 6) {
+    risks.push("Elevated work area increases fall damage risk.");
+  }
+  if (task?.metadata?.environment === "nether") {
+    risks.push("Building in the Nether requires fire resistance and ghast-proofing.");
+  }
+  if (task?.metadata?.weather === "stormy") {
+    risks.push("Stormy weather may cause lightning strikes; add lightning rods and shelter.");
+  }
+  if (task?.metadata?.threatLevel === "high") {
+    risks.push("Hostile mobs likely to interrupt construction; maintain perimeter defenses.");
+  }
+  if (floorArea && floorArea > 0) {
+    risks.push(`Large footprint (~${floorArea} blocks) increases build time and supply demand.`);
+  }
+
+  const volumeWeight = enclosedVolume && enclosedVolume > 0 ? enclosedVolume * 5 : 0;
+  const estimatedDuration = 14000 + blockCount * 90 + (height && height > 10 ? 4000 : 0) + volumeWeight;
+
+  const notes = [];
+  if (orientation) {
+    notes.push(`Align entrance toward ${orientation}.`);
+  }
+  if (task?.metadata?.deadline) {
+    notes.push(`Requested completion before ${task?.metadata?.deadline}.`);
+  }
+  if (floorArea) {
+    notes.push(`Estimated footprint area: ${floorArea} blocks.`);
+  }
+  if (enclosedVolume) {
+    notes.push(`Approximate enclosed volume: ${enclosedVolume} blocks.`);
+  }
+  if (missingTools.length > 0) {
+    notes.push(`Acquire missing tools: ${formatRequirementList(missingTools.map(name => ({ name })))}.`);
+  }
+
+  return createPlan({
+    task,
+    summary: `Construct ${blueprint} at ${targetDescription}.`,
+    steps,
+    estimatedDuration,
+    resources,
+    risks,
+    notes
+  });
+}

--- a/tasks/plan_combat.js
+++ b/tasks/plan_combat.js
@@ -1,0 +1,582 @@
+// tasks/plan_combat.js
+// Planning logic for combat engagements
+
+import {
+  createPlan,
+  createStep,
+  describeTarget,
+  normalizeItemName,
+  extractInventory,
+  hasInventoryItem,
+  formatRequirementList,
+  resolveQuantity
+} from "./helpers.js";
+
+function formatDisplayName(name) {
+  if (!name) {
+    return "Unknown";
+  }
+  return name
+    .split(" ")
+    .filter(Boolean)
+    .map(part => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+const enemyProfiles = {
+  "charged creeper": {
+    priority: 1,
+    reason: "Explosion is instantly lethal in close quarters.",
+    dodge: "Pepper with ranged attacks and retreat before detonation.",
+    risk: "Charged creeper blast radius will obliterate armor and terrain."
+  },
+  creeper: {
+    priority: 1,
+    reason: "Explodes for massive burst damage.",
+    dodge: "Keep 6-block distance, strike, then backpedal to avoid the fuse.",
+    risk: "Explosion can be fatal and destroy nearby structures."
+  },
+  "wither skeleton": {
+    priority: 1,
+    reason: "Inflicts wither effect and high melee damage.",
+    dodge: "Use shield blocks and strafe to avoid their sweeping attacks.",
+    risk: "Wither effect drains health rapidly if multiple hits land."
+  },
+  ghast: {
+    priority: 1,
+    reason: "Fireballs deal splash damage and knockback over voids.",
+    dodge: "Strafe laterally and reflect fireballs with melee swings or arrows.",
+    risk: "Fireball knockback can throw you into lava or off ledges."
+  },
+  evoker: {
+    priority: 1,
+    reason: "Summons vex and fang attacks if left alive.",
+    dodge: "Close distance quickly, circle around fangs, and burst them down.",
+    risk: "Vex summons overwhelm unprepared fighters quickly."
+  },
+  blaze: {
+    priority: 2,
+    reason: "Ranged fireballs ignite and stagger combatants.",
+    dodge: "Strafe between fireball volleys and use cover while closing in.",
+    risk: "Sustained fire damage requires fire resistance or constant dodging."
+  },
+  "cave spider": {
+    priority: 2,
+    reason: "Applies poison on hit and moves unpredictably.",
+    dodge: "Block tunnel entries and backstep during leap attacks.",
+    risk: "Poison stacks can be lethal without milk or regeneration."
+  },
+  "enderman": {
+    priority: 2,
+    reason: "High damage teleporting strikes once provoked.",
+    dodge: "Fight under a two-block shelter and avoid prolonged eye contact.",
+    risk: "Teleporting hits bypass shields if player is exposed."
+  },
+  "wither": {
+    priority: 1,
+    reason: "Boss-level destruction and wither skull projectiles.",
+    dodge: "Use cover to block skulls, strafe constantly, and drink milk to clear wither.",
+    risk: "Wither explosions devastate terrain and health rapidly."
+  },
+  "elder guardian": {
+    priority: 1,
+    reason: "Mining fatigue beams hinder escape and combat.",
+    dodge: "Break line of sight behind blocks to interrupt the laser.",
+    risk: "Mining fatigue prevents quick retreat or potion brewing underwater."
+  },
+  "guardian": {
+    priority: 2,
+    reason: "High ranged laser damage underwater.",
+    dodge: "Use cover pillars to reset laser charge and strafe underwater.",
+    risk: "Continuous beam damage stacks quickly without cover."
+  },
+  skeleton: {
+    priority: 2,
+    reason: "Accurate ranged attacks chip health from afar.",
+    dodge: "Strafe side-to-side and close the gap to disable bow fire.",
+    risk: "Arrow fire can knock you into hazards if ignored."
+  },
+  pillager: {
+    priority: 2,
+    reason: "Crossbow bolts penetrate shields when reloading.",
+    dodge: "Use shield timing and strafe between reloads to flank them.",
+    risk: "Bolts cause heavy knockback when fired in volleys."
+  },
+  vindicator: {
+    priority: 2,
+    reason: "Axe swings ignore shields and deal burst damage.",
+    dodge: "Backstep out of swing range, then counterattack while they recover.",
+    risk: "Shield-ignoring axes can drop health fast at close range."
+  },
+  witch: {
+    priority: 1,
+    reason: "Throws harmful splash potions and self-heals.",
+    dodge: "Approach in zigzags to avoid potions and burst with melee or arrows.",
+    risk: "Lingering poison and weakness potions prolong fights dangerously."
+  },
+  ravager: {
+    priority: 1,
+    reason: "Massive charge attacks break defenses and deal heavy damage.",
+    dodge: "Side-step charges and attack from the flanks after it lunges.",
+    risk: "Charge knockback can launch fighters into hazards."
+  },
+  spider: {
+    priority: 3,
+    reason: "Fast leaps can interrupt positioning.",
+    dodge: "Maintain vertical advantage or backpedal during leap windup.",
+    risk: "Leap knockback can push you off ledges in caves."
+  },
+  zombie: {
+    priority: 4,
+    reason: "Slow melee threat but swarms overwhelm.",
+    dodge: "Kite backwards, using knockback to keep distance from the group.",
+    risk: "Large packs can corner you if spacing is lost."
+  },
+  husk: {
+    priority: 3,
+    reason: "Applies hunger effect on hit.",
+    dodge: "Circle strafe to avoid swing range and counter when exposed.",
+    risk: "Hunger drains food, reducing regeneration mid-fight."
+  },
+  drowned: {
+    priority: 3,
+    reason: "Can throw tridents for burst ranged damage.",
+    dodge: "Dive under trident arcs and close distance quickly when they throw.",
+    risk: "Trident hits can be lethal without armor."
+  },
+  "stray": {
+    priority: 2,
+    reason: "Applies slowness arrows making dodging harder.",
+    dodge: "Use cover and shields, then rush before additional arrows land.",
+    risk: "Slowness makes retreat difficult in open biomes."
+  },
+  "hoglin": {
+    priority: 2,
+    reason: "Charges deal high knockback and damage.",
+    dodge: "Sidestep charges and counterattack while it recoils.",
+    risk: "Knockback can send you into lava in the Nether."
+  },
+  "piglin brute": {
+    priority: 1,
+    reason: "Massive melee damage without cooldown.",
+    dodge: "Use shields and sprint strafe to avoid consecutive hits.",
+    risk: "Two hits can defeat even armored fighters."
+  },
+  "zoglin": {
+    priority: 2,
+    reason: "Aggressive knockback even to armored players.",
+    dodge: "Circle strafe and strike after it lunges past you.",
+    risk: "Knockback can cause fall damage or lava spills."
+  },
+  "phantom": {
+    priority: 3,
+    reason: "Aerial dives harass from above when sleep deprived.",
+    dodge: "Look up and strafe when they swoop, striking during their dive path.",
+    risk: "Repeated dives add chip damage while other threats engage."
+  }
+};
+
+const defaultEnemyProfile = {
+  priority: 4,
+  reason: "Standard hostile threat—monitor but lower urgency.",
+  dodge: "Circle strafe to reduce incoming hits and retreat if pressure mounts.",
+  risk: "Unknown enemy behavior—remain alert for special attacks."
+};
+
+const enemyCountermeasures = {
+  "charged creeper": ["blast protection armor", "bow"],
+  creeper: ["blast protection armor", "shield"],
+  "wither skeleton": ["milk bucket", "smite sword"],
+  ghast: ["bow", "fire resistance potion"],
+  evoker: ["milk bucket", "bow"],
+  blaze: ["fire resistance potion", "bow"],
+  "cave spider": ["milk bucket", "instant health potion"],
+  enderman: ["pumpkin helmet", "looting sword"],
+  wither: ["milk bucket", "regeneration potion", "smite sword"],
+  "elder guardian": ["water breathing potion", "milk bucket", "doors"],
+  guardian: ["depth strider boots", "water breathing potion", "doors"],
+  skeleton: ["shield", "projectile protection armor"],
+  pillager: ["shield", "projectile protection armor"],
+  vindicator: ["shield", "strength potion"],
+  witch: ["milk bucket", "instant health potion"],
+  ravager: ["shield", "strength potion"],
+  spider: ["sweeping edge sword"],
+  zombie: ["smite sword"],
+  husk: ["milk bucket"],
+  drowned: ["shield", "respiration helmet"],
+  stray: ["shield", "milk bucket"],
+  hoglin: ["fire resistance potion", "shield"],
+  "piglin brute": ["netherite armor", "shield"],
+  zoglin: ["shield", "feather falling boots"],
+  phantom: ["bow", "slow falling potion"]
+};
+
+const environmentProfiles = [
+  {
+    matches: env => env.includes("nether"),
+    description: "Use fireproof blocks for cover and keep fire resistance active while avoiding lava edges.",
+    hazards: ["Lava pools, fire damage, and narrow ledges increase knockback danger."],
+    counterItems: ["fire resistance potion"]
+  },
+  {
+    matches: env => env.includes("ocean") || env.includes("underwater") || env.includes("sea"),
+    description: "Maintain water breathing and night vision while using blocks or doors to reset guardian lasers.",
+    hazards: ["Limited mobility and drowning risk if respiration expires."],
+    counterItems: ["water breathing potion", "doors", "night vision potion"]
+  },
+  {
+    matches: env => env.includes("end"),
+    description: "Place water buckets or scaffolding to prevent void falls and keep slow falling active when near ledges.",
+    hazards: ["Void falls are lethal and endermen aggro easily on open platforms."],
+    counterItems: ["slow falling potion", "water bucket"]
+  },
+  {
+    matches: env => env.includes("cave") || env.includes("ravine") || env.includes("mine"),
+    description: "Light choke points, clear drop hazards, and fight from secure tunnels to avoid surprise attacks.",
+    hazards: ["Low visibility and uneven terrain enable ambushes."],
+    counterItems: ["torches", "blocks"]
+  }
+];
+
+export function planCombatTask(task, context = {}) {
+  const target = normalizeItemName(task?.metadata?.targetEntity || task.details || "hostile mob");
+  const targetDescription = describeTarget(task.target);
+  const backupPlan = normalizeItemName(task?.metadata?.fallback || "retreat to base");
+  const tactic = normalizeItemName(task?.metadata?.tactic || "melee");
+  const enemyCount = resolveQuantity(task?.metadata?.count ?? task?.metadata?.enemyCount, 1) || 1;
+  const support = normalizeItemName(task?.metadata?.support || "");
+  const environment = normalizeItemName(task?.metadata?.environment || context?.environment || "overworld");
+  const additionalTargets = [];
+
+  if (Array.isArray(task?.metadata?.enemyTypes)) {
+    additionalTargets.push(...task.metadata.enemyTypes.map(normalizeItemName));
+  }
+  if (Array.isArray(task?.metadata?.additionalHostiles)) {
+    additionalTargets.push(...task.metadata.additionalHostiles.map(normalizeItemName));
+  }
+  if (typeof task?.metadata?.secondaryTarget === "string") {
+    additionalTargets.push(normalizeItemName(task.metadata.secondaryTarget));
+  }
+
+  const enemyTypes = [...new Set([target, ...additionalTargets].filter(Boolean))];
+  const enemyDetails = enemyTypes.map(name => ({
+    name,
+    displayName: formatDisplayName(name),
+    ...(enemyProfiles[name] || defaultEnemyProfile)
+  }));
+
+  const explicitPriority = Array.isArray(task?.metadata?.priorityTargets)
+    ? task.metadata.priorityTargets.map(normalizeItemName).filter(Boolean)
+    : [];
+
+  const explicitSet = new Set(explicitPriority);
+  const explicitDetails = explicitPriority
+    .map(name => enemyDetails.find(detail => detail.name === name) || {
+      name,
+      displayName: formatDisplayName(name),
+      ...defaultEnemyProfile
+    });
+
+  const remainingEnemies = enemyDetails.filter(detail => !explicitSet.has(detail.name));
+
+  const prioritizedEnemies = [
+    ...explicitDetails,
+    ...remainingEnemies.sort((a, b) => {
+      if (a.priority !== b.priority) {
+        return a.priority - b.priority;
+      }
+      return a.displayName.localeCompare(b.displayName);
+    })
+  ];
+
+  const priorityDescription = prioritizedEnemies.length > 1
+    ? prioritizedEnemies
+        .map((detail, index) => `${index + 1}. ${detail.displayName} - ${detail.reason}`)
+        .join("; ")
+    : `Focus on eliminating ${prioritizedEnemies[0]?.displayName || formatDisplayName(target)} quickly.`;
+
+  const dodgeAdviceList = prioritizedEnemies.map(detail => ({
+    enemy: detail.displayName,
+    dodge: detail.dodge
+  }));
+
+  const dodgeDescription = dodgeAdviceList.length > 0
+    ? dodgeAdviceList
+        .map(entry => `${entry.enemy}: ${entry.dodge}`)
+        .join(" ")
+    : "Maintain spacing, strafe, and disengage if health drops critically.";
+
+  const recommendedCounterItems = new Set();
+
+  enemyTypes.forEach(name => {
+    const counters = enemyCountermeasures[name];
+    if (Array.isArray(counters)) {
+      counters.forEach(item => {
+        const normalized = normalizeItemName(item);
+        if (normalized && normalized !== "unspecified item") {
+          recommendedCounterItems.add(normalized);
+        }
+      });
+    }
+  });
+
+  const environmentProfile = environmentProfiles.find(profile => {
+    try {
+      return profile.matches(environment);
+    } catch (error) {
+      return false;
+    }
+  });
+
+  if (environmentProfile?.counterItems) {
+    environmentProfile.counterItems.forEach(item => {
+      const normalized = normalizeItemName(item);
+      if (normalized && normalized !== "unspecified item") {
+        recommendedCounterItems.add(normalized);
+      }
+    });
+  }
+
+  const requiredEquipment = [
+    normalizeItemName(task?.metadata?.primaryWeapon || (tactic.includes("ranged") ? "bow" : "sword")),
+    normalizeItemName(task?.metadata?.secondaryWeapon || (tactic.includes("shield") ? "shield" : "")),
+    "armor"
+  ].filter(Boolean);
+
+  const potions = Array.isArray(task?.metadata?.potions)
+    ? task.metadata.potions.map(normalizeItemName)
+    : task?.metadata?.potions
+    ? [normalizeItemName(task.metadata.potions)]
+    : [];
+
+  const inventory = extractInventory(context);
+  const missingEquipment = requiredEquipment.filter(item => !hasInventoryItem(inventory, item));
+  const missingPotions = potions.filter(item => !hasInventoryItem(inventory, item));
+  const counterItems = Array.from(recommendedCounterItems);
+  const missingCounterItems = counterItems.filter(item => !hasInventoryItem(inventory, item));
+  const missingPotionsSummary = formatRequirementList(missingPotions);
+  const counterItemsSummary = formatRequirementList(counterItems);
+
+  const steps = [];
+
+  const missingEquipmentSummary = formatRequirementList(missingEquipment);
+  const prepareDescription = missingEquipment.length > 0
+    ? missingEquipmentSummary
+      ? `Acquire combat gear (${missingEquipmentSummary}) and equip before engaging ${target}.`
+      : `Acquire necessary combat gear and equip before engaging ${target}.`
+    : `Equip enchanted weapons, shields, armor, and carry potions or golden apples before engaging ${target}.`;
+
+  steps.push(
+    createStep({
+      title: "Prepare",
+      type: "preparation",
+      description: prepareDescription,
+      metadata: { equipment: requiredEquipment, missing: missingEquipment }
+    })
+  );
+
+  if (potions.length > 0) {
+    steps.push(
+      createStep({
+        title: "Buff up",
+        type: "preparation",
+        description:
+          missingPotions.length > 0
+            ? missingPotionsSummary
+              ? `Brew or retrieve potions (${missingPotionsSummary}) prior to combat.`
+              : "Brew or retrieve potions prior to combat."
+            : `Consume or carry potions (${potions.join(", ")}) to gain advantages.`,
+        metadata: { potions, missing: missingPotions }
+      })
+    );
+  }
+
+  if (task?.metadata?.traps) {
+    steps.push(
+      createStep({
+        title: "Set traps",
+        type: "preparation",
+        description: `Deploy traps or defensive structures before provoking ${target}.`,
+        metadata: { traps: task.metadata.traps }
+      })
+    );
+  }
+
+  if (counterItems.length > 0) {
+    steps.push(
+      createStep({
+        title: "Prepare countermeasures",
+        type: "preparation",
+        description:
+          missingCounterItems.length > 0
+            ? counterItemsSummary
+              ? `Secure specialized countermeasures (${counterItemsSummary}) before engaging.`
+              : "Secure specialized countermeasures before engaging."
+            : `Equip specialized countermeasures (${counterItemsSummary}) to neutralize enemy abilities.`,
+        metadata: { counterItems, missing: missingCounterItems }
+      })
+    );
+  }
+
+  if (prioritizedEnemies.length > 0) {
+    steps.push(
+      createStep({
+        title: "Prioritize threats",
+        type: "strategy",
+        description: priorityDescription,
+        metadata: {
+          priority: prioritizedEnemies.map(detail => ({
+            enemy: detail.displayName,
+            priority: detail.priority,
+            reason: detail.reason
+          }))
+        }
+      })
+    );
+  }
+
+  if (dodgeAdviceList.length > 0) {
+    steps.push(
+      createStep({
+        title: "Position and dodge",
+        type: "maneuver",
+        description: dodgeDescription,
+        metadata: { dodges: dodgeAdviceList }
+      })
+    );
+  }
+
+  const engageDescriptionParts = [
+    `Engage ${target} near ${targetDescription} using ${tactic} tactics while maintaining spacing to avoid damage.`
+  ];
+
+  if (prioritizedEnemies.length > 1) {
+    engageDescriptionParts.push(
+      `Eliminate threats following the priority order: ${prioritizedEnemies
+        .map(detail => detail.displayName)
+        .join(", ")}.`
+    );
+  }
+
+  if (environmentProfile?.description) {
+    steps.push(
+      createStep({
+        title: "Control the battlefield",
+        type: "maneuver",
+        description: environmentProfile.description,
+        metadata: {
+          environment,
+          hazards: environmentProfile.hazards || [],
+          counterItems: environmentProfile.counterItems
+            ? environmentProfile.counterItems.map(normalizeItemName)
+            : []
+        }
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Engage",
+      type: "action",
+      description: engageDescriptionParts.join(" "),
+      metadata: {
+        enemyCount,
+        tactic,
+        priorityOrder: prioritizedEnemies.map(detail => detail.displayName)
+      }
+    })
+  );
+
+  if (support && support !== "unspecified item") {
+    steps.push(
+      createStep({
+        title: "Coordinate support",
+        type: "communication",
+        description: `Coordinate with ${support} for focus fire or healing as needed.`,
+        metadata: { support }
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Secure area",
+      type: "cleanup",
+      description: `Light up surroundings, eliminate remaining threats, and collect drops from ${target}.`
+    })
+  );
+
+  steps.push(
+    createStep({
+      title: "Fallback plan",
+      type: "contingency",
+      description: `If overwhelmed, ${backupPlan} and regroup before another attempt.`,
+      metadata: { fallback: backupPlan }
+    })
+  );
+
+  const estimatedDuration = 9000 + enemyCount * 1200;
+  const resources = [
+    ...new Set(
+      [
+        ...requiredEquipment,
+        ...potions,
+        ...counterItems,
+        ...prioritizedEnemies.map(detail => detail.displayName.toLowerCase()),
+        target,
+        support
+      ].filter(name => name && name !== "unspecified item")
+    )
+  ];
+
+  const risks = [];
+  if (missingEquipment.length > 0) {
+    risks.push("Missing equipment could reduce combat effectiveness.");
+  }
+  if (enemyCount > 3) {
+    risks.push("Multiple hostiles present—expect extended fight.");
+  }
+  if (environment.includes("nether")) {
+    risks.push("Fire and lava hazards require resistance.");
+  }
+  if (missingCounterItems.length > 0) {
+    risks.push("Missing specialized countermeasures leaves you vulnerable to unique enemy abilities.");
+  }
+  prioritizedEnemies.forEach(detail => {
+    if (detail.risk && !risks.includes(detail.risk)) {
+      risks.push(detail.risk);
+    }
+  });
+  if (environmentProfile?.hazards) {
+    environmentProfile.hazards.forEach(hazard => {
+      if (!risks.includes(hazard)) {
+        risks.push(hazard);
+      }
+    });
+  }
+
+  const notes = [];
+  if (task?.metadata?.lootPriority) {
+    notes.push(`Collect priority loot: ${task.metadata.lootPriority}.`);
+  }
+  if (task?.metadata?.spawnControl) {
+    notes.push(`Disable spawner at ${describeTarget(task.metadata.spawnControl)} if possible.`);
+  }
+  if (environmentProfile?.description) {
+    const battlefieldNote = `Battlefield control guidance: ${environmentProfile.description}`;
+    if (!notes.includes(battlefieldNote)) {
+      notes.push(battlefieldNote);
+    }
+  }
+
+  return createPlan({
+    task,
+    summary: `Defeat ${target} near ${targetDescription}.`,
+    steps,
+    estimatedDuration,
+    resources,
+    risks,
+    notes
+  });
+}

--- a/tasks/plan_craft.js
+++ b/tasks/plan_craft.js
@@ -1,0 +1,471 @@
+// tasks/plan_craft.js
+// Planning logic for crafting requests
+
+import {
+  createPlan,
+  createStep,
+  describeTarget,
+  normalizeItemName,
+  extractInventory,
+  hasInventoryItem,
+  formatRequirementList,
+  resolveQuantity,
+  countInventoryItems
+} from "./helpers.js";
+
+function normalizeList(value) {
+  if (!value) {
+    return [];
+  }
+  if (Array.isArray(value)) {
+    return value
+      .map(entry => (typeof entry === "string" ? normalizeItemName(entry) : normalizeItemName(entry?.name || entry?.item)))
+      .filter(name => name && name !== "unspecified item");
+  }
+  if (typeof value === "string") {
+    const normalized = normalizeItemName(value);
+    return normalized && normalized !== "unspecified item" ? [normalized] : [];
+  }
+  if (typeof value === "object") {
+    return Object.values(value)
+      .map(entry => normalizeItemName(entry))
+      .filter(name => name && name !== "unspecified item");
+  }
+  return [];
+}
+
+function determineStationProfile(stationName, metadata = {}) {
+  const name = stationName || "";
+  const fuelOptions = normalizeList(metadata.fuel || metadata.fuels || metadata.requiredFuel);
+
+  if (name.includes("furnace") || name.includes("smoker")) {
+    return {
+      type: "smelting",
+      verb: name.includes("smoker") ? "smoke" : "smelt",
+      command: null,
+      requiresFuel: true,
+      fuelOptions: fuelOptions.length > 0 ? fuelOptions : ["coal", "charcoal", "logs"],
+      itemsPerFuel: metadata.itemsPerFuel ? resolveQuantity(metadata.itemsPerFuel, 8) : 8,
+      itemsPerOperation: metadata.itemsPerOperation ? resolveQuantity(metadata.itemsPerOperation, 1) : 1,
+      postCollection: `Collect finished ${metadata.output || "items"} from the ${name}.`,
+      notes: "Furnace operations consume fuel; ensure hopper outputs aren't clogged."
+    };
+  }
+
+  if (name.includes("brewing")) {
+    return {
+      type: "brewing",
+      verb: "brew",
+      command: null,
+      requiresFuel: true,
+      fuelOptions: fuelOptions.length > 0 ? fuelOptions : ["blaze powder"],
+      fuelPerBatch: metadata.fuelPerBatch ? resolveQuantity(metadata.fuelPerBatch, 1) : 1,
+      bottlesPerBatch: metadata.bottlesPerBatch ? resolveQuantity(metadata.bottlesPerBatch, 3) : 3,
+      postCollection: "Collect finished potions and clear the brewing stand.",
+      notes: "Brewing requires blaze powder fuel and filled bottles; queue reagents in order."
+    };
+  }
+
+  if (name.includes("smithing")) {
+    return {
+      type: "smithing",
+      verb: "reforge",
+      command: null,
+      requiresFuel: false,
+      template: normalizeItemName(metadata.template || metadata.smithingTemplate),
+      notes: "Ensure the smithing template and upgrade material are available before reforging."
+    };
+  }
+
+  if (name.includes("anvil")) {
+    return {
+      type: "anvil",
+      verb: "combine",
+      command: null,
+      requiresFuel: false,
+      xpCost: resolveQuantity(metadata.xpCost, null),
+      notes: "Combining items on an anvil consumes XP levels and damages the anvil over time."
+    };
+  }
+
+  if (name.includes("stonecutter")) {
+    return {
+      type: "stonecutting",
+      verb: "cut",
+      command: null,
+      requiresFuel: false,
+      notes: "Stonecutting converts blocks efficiently; confirm exact patterns before cutting."
+    };
+  }
+
+  return {
+    type: "crafting",
+    verb: "craft",
+    command: "/craft",
+    requiresFuel: false,
+    notes: metadata?.notes || null
+  };
+}
+
+function parseIngredients(task) {
+  const rawIngredients = Array.isArray(task?.metadata?.ingredients)
+    ? task.metadata.ingredients
+    : [];
+
+  const normalized = rawIngredients
+    .map(entry => {
+      if (typeof entry === "string") {
+        return { name: normalizeItemName(entry) };
+      }
+      if (entry && typeof entry === "object") {
+        const name = normalizeItemName(entry.name || entry.item || entry.id);
+        const count = resolveQuantity(entry.count ?? entry.quantity, null);
+        return { name, count };
+      }
+      return null;
+    })
+    .filter(Boolean);
+
+  if (normalized.length > 0) {
+    return normalized;
+  }
+
+  if (task?.metadata?.recipe && typeof task.metadata.recipe === "object") {
+    return Object.entries(task.metadata.recipe).map(([name, count]) => ({
+      name: normalizeItemName(name),
+      count: resolveQuantity(count, null)
+    }));
+  }
+
+  const fallback = normalizeItemName(task?.metadata?.primaryIngredient || task?.details || "materials");
+  return [{ name: fallback }];
+}
+
+export function planCraftTask(task, context = {}) {
+  const item = normalizeItemName(task?.metadata?.item || task.details);
+  const station = normalizeItemName(task?.metadata?.station || "crafting table");
+  const storage = normalizeItemName(task?.metadata?.storage || task?.metadata?.dropOff || "nearest chest");
+  const targetDescription = describeTarget(task.target);
+  const requiresAutomation = Boolean(task?.metadata?.automation || task?.metadata?.autocrafter);
+  const stationProfile = determineStationProfile(station, task?.metadata || {});
+
+  const inventory = extractInventory(context);
+  const currentStock = countInventoryItems(inventory, item);
+  const baseQuantity = resolveQuantity(task?.metadata?.quantity ?? task?.metadata?.count, 1) || 1;
+  const maintainMinimum = resolveQuantity(
+    task?.metadata?.maintainMinimum ?? task?.metadata?.minStock ?? task?.metadata?.maintain,
+    null
+  );
+  const desiredStock = resolveQuantity(
+    task?.metadata?.desiredStock ?? task?.metadata?.targetStock ?? task?.metadata?.restockTarget,
+    null
+  );
+  const buffer = resolveQuantity(task?.metadata?.buffer ?? task?.metadata?.extra ?? 0, 0) || 0;
+  const exactQuantity = resolveQuantity(task?.metadata?.exactQuantity, null);
+
+  let quantity = baseQuantity;
+  const quantityReasons = [];
+
+  if (maintainMinimum && currentStock < maintainMinimum) {
+    const deficit = maintainMinimum - currentStock;
+    quantity = Math.max(quantity, deficit);
+    quantityReasons.push(`inventory below minimum (${currentStock}/${maintainMinimum})`);
+  }
+
+  if (desiredStock && currentStock + quantity < desiredStock) {
+    const required = desiredStock - currentStock;
+    quantity = Math.max(quantity, required);
+    quantityReasons.push(`target stock of ${desiredStock} requires ${required}`);
+  }
+
+  if (buffer > 0) {
+    quantity += buffer;
+    quantityReasons.push(`include buffer of ${buffer}`);
+  }
+
+  if (exactQuantity && exactQuantity > 0) {
+    quantity = exactQuantity;
+    quantityReasons.push(`exact quantity override to ${exactQuantity}`);
+  }
+
+  if (!Number.isFinite(quantity) || quantity <= 0) {
+    quantity = 1;
+  }
+
+  const ingredients = parseIngredients(task);
+  const missingIngredients = ingredients.filter(ingredient => {
+    if (!ingredient?.name || ingredient.name === "unspecified item") {
+      return false;
+    }
+    if (ingredient.count && ingredient.count > 0) {
+      return !hasInventoryItem(inventory, ingredient.name, ingredient.count * quantity);
+    }
+    return !hasInventoryItem(inventory, ingredient.name, quantity);
+  });
+
+  const ingredientSummary = formatRequirementList(
+    ingredients.map(ing => ({ ...ing, count: ing.count ? ing.count * quantity : ing.count }))
+  );
+  const missingSummary = formatRequirementList(missingIngredients);
+
+  const steps = [];
+
+  if (maintainMinimum || desiredStock || buffer > 0 || quantityReasons.length > 0) {
+    const reasonText = quantityReasons.length > 0
+      ? quantityReasons.join("; ")
+      : "Maintain healthy stock levels before heading out.";
+    steps.push(
+      createStep({
+        title: "Assess stock levels",
+        type: "analysis",
+        description: `Inventory shows ${currentStock} ${item}. ${reasonText}.`,
+        metadata: {
+          currentStock,
+          maintainMinimum,
+          desiredStock,
+          buffer,
+          plannedQuantity: quantity
+        }
+      })
+    );
+  }
+
+  const restockIngredientsDescription = missingSummary
+    ? `Acquire missing components for ${item}: ${missingSummary}.`
+    : `Acquire missing components for ${item} before starting.`;
+  const verifyIngredientsDescription = ingredientSummary
+    ? `Confirm ingredients for ${item} x${quantity}: ${ingredientSummary}.`
+    : `Confirm ingredients for ${item} x${quantity} are available.`;
+
+  steps.push(
+    createStep({
+      title: missingIngredients.length > 0 ? "Restock ingredients" : "Verify ingredients",
+      type: "inventory",
+      description:
+        missingIngredients.length > 0 ? restockIngredientsDescription : verifyIngredientsDescription,
+      metadata: { ingredients, missing: missingIngredients, quantity }
+    })
+  );
+
+  if (task?.metadata?.subcomponents) {
+    const rawSubcomponents = task.metadata.subcomponents;
+    const normalizedSubcomponents = Array.isArray(rawSubcomponents)
+      ? rawSubcomponents.map(entry =>
+          typeof entry === "string"
+            ? { name: normalizeItemName(entry) }
+            : {
+                name: normalizeItemName(entry?.name || entry?.item),
+                count: resolveQuantity(entry?.count ?? entry?.quantity, null)
+              }
+        )
+      : Object.entries(rawSubcomponents).map(([name, count]) => ({
+          name: normalizeItemName(name),
+          count: resolveQuantity(count, null)
+        }));
+    const subcomponentsSummary = formatRequirementList(normalizedSubcomponents) || "required subcomponents";
+
+    steps.push(
+      createStep({
+        title: "Craft subcomponents",
+        type: "preparation",
+        description: `Craft prerequisite parts (${subcomponentsSummary}).`,
+        metadata: { subcomponents: normalizedSubcomponents }
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Move to workstation",
+      type: "movement",
+      description: `Travel to ${station} located at ${targetDescription}.`,
+      metadata: { station, process: stationProfile.type }
+    })
+  );
+
+  let fuelStatus = null;
+  if (stationProfile.requiresFuel) {
+    const itemsPerFuel = stationProfile.itemsPerFuel || 1;
+    const perBatch = stationProfile.fuelPerBatch || 1;
+    const operationsNeeded = Math.max(1, Math.ceil((quantity * (stationProfile.itemsPerOperation || 1)) / itemsPerFuel));
+    const fuelNeeded = Math.max(perBatch, operationsNeeded);
+    const fuelOptions = stationProfile.fuelOptions || [];
+    const hasFuel = fuelOptions.some(option => hasInventoryItem(inventory, option, fuelNeeded));
+    fuelStatus = { fuelNeeded, fuelOptions, hasFuel };
+    const fuelList = fuelOptions.length > 0 ? fuelOptions.join(", ") : "fuel";
+
+    steps.push(
+      createStep({
+        title: "Load fuel",
+        type: "inventory",
+        description: `Insert approximately ${fuelNeeded} ${fuelList} into the ${station} to power the process.`,
+        metadata: { fuelOptions, fuelNeeded }
+      })
+    );
+
+    if (stationProfile.type === "brewing") {
+      const bottlesNeeded = Math.max(1, Math.ceil(quantity / (stationProfile.bottlesPerBatch || 3)) * (stationProfile.bottlesPerBatch || 3));
+      steps.push(
+        createStep({
+          title: "Prep bottles",
+          type: "inventory",
+          description: `Fill and place ${bottlesNeeded} water bottles plus initial reagents into the brewing stand.`,
+          metadata: { bottlesNeeded }
+        })
+      );
+    }
+
+    if (stationProfile.type === "smelting") {
+      steps.push(
+        createStep({
+          title: "Queue inputs",
+          type: "inventory",
+          description: `Load raw ingredients for ${item} into the ${station} input slots.`,
+          metadata: { ingredients, quantity }
+        })
+      );
+    }
+  }
+
+  if (!stationProfile.requiresFuel && stationProfile.type === "smithing" && stationProfile.template) {
+    steps.push(
+      createStep({
+        title: "Slot smithing template",
+        type: "preparation",
+        description: `Place the ${stationProfile.template} template into the smithing table before combining materials.`,
+        metadata: { template: stationProfile.template }
+      })
+    );
+  }
+
+  if (!stationProfile.requiresFuel && stationProfile.type === "anvil" && stationProfile.xpCost) {
+    steps.push(
+      createStep({
+        title: "Verify XP levels",
+        type: "analysis",
+        description: `Ensure at least ${stationProfile.xpCost} XP levels are available to complete the anvil combination.`,
+        metadata: { xpCost: stationProfile.xpCost }
+      })
+    );
+  }
+
+  if (requiresAutomation) {
+    steps.push(
+      createStep({
+        title: "Configure automation",
+        type: "configuration",
+        description: `Load the recipe into the ${station} autocrafter and prime input buffers.`
+      })
+    );
+  }
+
+  const craftVerb = stationProfile.verb || "craft";
+  const craftDescription = quantity > 1
+    ? `Use the ${station} to ${craftVerb} ${quantity}x ${item}, arranging ingredients per recipe.`
+    : `Use the ${station} to ${craftVerb} ${item}, arranging ingredients per recipe.`;
+  let craftCommand = null;
+  if (stationProfile.command === "/craft") {
+    const craftCommandBase = `/craft ${item.replace(/\s+/g, "_")}`;
+    craftCommand = quantity > 1 ? `${craftCommandBase} ${quantity}` : craftCommandBase;
+  }
+
+  steps.push(
+    createStep({
+      title: "Craft item",
+      type: "action",
+      description: craftDescription,
+      command: craftCommand
+    })
+  );
+
+  if (stationProfile.postCollection) {
+    steps.push(
+      createStep({
+        title: "Collect output",
+        type: "action",
+        description: stationProfile.postCollection,
+        metadata: { station }
+      })
+    );
+  }
+
+  if (task?.metadata?.qualityCheck) {
+    steps.push(
+      createStep({
+        title: "Inspect output",
+        type: "quality",
+        description: `Verify enchantments or durability on the crafted ${item} before delivery.`
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Store output",
+      type: "storage",
+      description: `Place the crafted ${item} into the ${storage} and report quantity produced.`,
+      metadata: { container: storage, quantity }
+    })
+  );
+
+  const estimatedDuration = 8000 + ingredients.length * 1500 + Math.max(0, quantity - 1) * 1200;
+  const resources = [item, station, storage]
+    .concat(ingredients.map(ing => ing.name))
+    .concat(stationProfile?.fuelOptions || [])
+    .concat(stationProfile?.template ? [stationProfile.template] : [])
+    .filter(Boolean);
+  const uniqueResources = [...new Set(resources.filter(name => name && name !== "unspecified item"))];
+
+  const risks = [];
+  if (missingIngredients.length > 0) {
+    risks.push("Insufficient ingredients could delay crafting.");
+  }
+  if (fuelStatus && !fuelStatus.hasFuel) {
+    risks.push("Fuel reserves are low; gather additional fuel before processing.");
+  }
+  if (maintainMinimum && currentStock + quantity < maintainMinimum) {
+    risks.push(`Even after crafting, stock may remain below minimum (${maintainMinimum}).`);
+  }
+  if (desiredStock && currentStock + quantity < desiredStock) {
+    risks.push(`Plan crafts ${quantity}, still short of desired stock ${desiredStock}.`);
+  }
+  if (requiresAutomation) {
+    risks.push("Autocrafter misconfiguration may waste materials.");
+  }
+  if (stationProfile.type === "anvil") {
+    risks.push("Combining items may reduce anvil durability; prepare a backup anvil.");
+  }
+  if (stationProfile.type === "brewing") {
+    risks.push("Brewing sequences are timing-sensitive; avoid swapping reagents mid-cycle.");
+  }
+
+  const notes = [];
+  if (task?.metadata?.deliverTo) {
+    notes.push(`Deliver finished items to ${task.metadata.deliverTo}.`);
+  }
+  if (task?.metadata?.recipeBook) {
+    notes.push("Ensure the recipe book is unlocked for this item.");
+  }
+  if (task?.metadata?.upcomingUse) {
+    notes.push(`Crafting supports upcoming need: ${task.metadata.upcomingUse}.`);
+  }
+  if (quantityReasons.length > 0) {
+    notes.push(`Quantity rationale: ${quantityReasons.join("; ")}.`);
+  }
+  if (stationProfile.notes) {
+    notes.push(stationProfile.notes);
+  }
+  if (fuelStatus && fuelStatus.fuelOptions?.length > 0) {
+    notes.push(`Fuel options: ${fuelStatus.fuelOptions.join(", ")}; estimated need ${fuelStatus.fuelNeeded}.`);
+  }
+
+  return createPlan({
+    task,
+    summary: quantity > 1 ? `Craft ${quantity}x ${item} using the ${station}.` : `Craft ${item} using the ${station}.`,
+    steps,
+    estimatedDuration,
+    resources: uniqueResources,
+    risks,
+    notes
+  });
+}

--- a/tasks/plan_explore.js
+++ b/tasks/plan_explore.js
@@ -1,0 +1,176 @@
+// tasks/plan_explore.js
+// Planning logic for exploration or scouting tasks
+
+import {
+  createPlan,
+  createStep,
+  describeTarget,
+  normalizeItemName,
+  extractInventory,
+  hasInventoryItem,
+  formatRequirementList,
+  resolveQuantity
+} from "./helpers.js";
+
+export function planExploreTask(task, context = {}) {
+  const targetDescription = describeTarget(task.target);
+  const poi = Array.isArray(task?.metadata?.pointsOfInterest)
+    ? task.metadata.pointsOfInterest.map(normalizeItemName)
+    : [];
+  const preferredTool = normalizeItemName(task?.metadata?.tool || "map");
+  const radius = resolveQuantity(task?.metadata?.radius ?? task?.metadata?.range, null);
+  const transport = normalizeItemName(task?.metadata?.transport || "foot");
+  const suppliesRaw = Array.isArray(task?.metadata?.supplies)
+    ? task.metadata.supplies
+    : task?.metadata?.supplies && typeof task.metadata.supplies === "object"
+    ? Object.entries(task.metadata.supplies).map(([name, count]) => ({ name, count }))
+    : task?.metadata?.supplies
+    ? [task.metadata.supplies]
+    : [];
+  const survivalKit = ["food", "torches", "bed", ...suppliesRaw];
+  const environment = normalizeItemName(task?.metadata?.environment || context?.environment || "overworld");
+
+  const inventory = extractInventory(context);
+  const normalizedSupplies = survivalKit
+    .map(item => {
+      if (typeof item === "string") {
+        return { name: normalizeItemName(item) };
+      }
+      if (item && typeof item === "object") {
+        return {
+          name: normalizeItemName(item.name || item.item || item.id || Object.keys(item)[0]),
+          count: resolveQuantity(item.count ?? item.quantity ?? Object.values(item)[0], null)
+        };
+      }
+      return null;
+    })
+    .filter(Boolean);
+  const missingSupplies = normalizedSupplies.filter(supply =>
+    supply?.name ? !hasInventoryItem(inventory, supply.name) : false
+  );
+
+  const steps = [];
+
+  const suppliesSummary = formatRequirementList(normalizedSupplies) || "expedition supplies";
+  const missingSuppliesSummary = formatRequirementList(missingSupplies);
+
+  steps.push(
+    createStep({
+      title: "Prepare expedition",
+      type: "preparation",
+      description:
+        missingSupplies.length > 0
+          ? missingSuppliesSummary
+            ? `Stock up on expedition supplies (${missingSuppliesSummary}) and set spawn/bed location.`
+            : "Stock up on expedition supplies and set spawn/bed location."
+          : `Stock up on ${suppliesSummary} and set spawn/bed location before departure.`,
+      metadata: { supplies: normalizedSupplies, missing: missingSupplies }
+    })
+  );
+
+  steps.push(
+    createStep({
+      title: "Calibrate tools",
+      type: "preparation",
+      description: `Ensure ${preferredTool} and navigation aids (compass, lodestone) are synchronized.`,
+      metadata: { tool: preferredTool }
+    })
+  );
+
+  if (transport && transport !== "foot") {
+    steps.push(
+      createStep({
+        title: "Ready transport",
+        type: "preparation",
+        description: `Prepare ${transport} for long-range travel, including fuel or feed.`,
+        metadata: { transport }
+      })
+    );
+  }
+
+  const travelDescription = radius
+    ? `Explore within ${radius} blocks of ${targetDescription}, marking safe routes back.`
+    : `Explore the region around ${targetDescription}, marking safe routes back.`;
+
+  steps.push(
+    createStep({
+      title: "Travel",
+      type: "movement",
+      description: travelDescription,
+      metadata: { radius, transport }
+    })
+  );
+
+  if (task?.metadata?.mapOutChunks) {
+    steps.push(
+      createStep({
+        title: "Map chunks",
+        type: "observation",
+        description: `Chart chunk boundaries and update locator maps for the region.`
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Survey",
+      type: "observation",
+      description: poi.length > 0
+        ? `Document points of interest: ${poi.join(", ")}.`
+        : "Document notable terrain, structures, and resources encountered.",
+      metadata: { poi }
+    })
+  );
+
+  if (task?.metadata?.waypoints) {
+    steps.push(
+      createStep({
+        title: "Place waypoints",
+        type: "action",
+        description: `Drop markers or beacons at strategic spots for future travel.`,
+        metadata: { waypoints: task.metadata.waypoints }
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Report",
+      type: "report",
+      description: `Return to base and share coordinates, screenshots, or notes from the exploration.`,
+      metadata: { report: task?.metadata?.reportFormat || "summary" }
+    })
+  );
+
+  const estimatedDuration = 14000 + (radius ? radius * 120 : 5000);
+  const resources = [preferredTool, transport]
+    .concat(normalizedSupplies.map(supply => supply.name))
+    .filter(name => name && name !== "unspecified item");
+  const uniqueResources = [...new Set(resources)];
+
+  const risks = [];
+  if (environment.includes("nether")) {
+    risks.push("Nether environment requires fire resistance and careful navigation.");
+  }
+  if (task?.metadata?.nightRun) {
+    risks.push("Night exploration increases hostile mob encounters.");
+  }
+
+  const notes = [];
+  if (task?.metadata?.returnBy) {
+    notes.push(`Return before ${task.metadata.returnBy}.`);
+  }
+  if (task?.metadata?.lootPriority) {
+    notes.push(`Priority loot: ${task.metadata.lootPriority}.`);
+  }
+
+  return createPlan({
+    task,
+    summary: `Explore area near ${targetDescription}.`,
+    steps,
+    estimatedDuration,
+    resources: uniqueResources,
+    risks,
+    notes
+  });
+}

--- a/tasks/plan_gather.js
+++ b/tasks/plan_gather.js
@@ -1,0 +1,235 @@
+// tasks/plan_gather.js
+// Planning logic for gathering crops or resources
+
+import {
+  createPlan,
+  createStep,
+  describeTarget,
+  normalizeItemName,
+  extractInventory,
+  hasInventoryItem,
+  formatRequirementList,
+  resolveQuantity
+} from "./helpers.js";
+
+export function planGatherTask(task, context = {}) {
+  const resource = normalizeItemName(task?.metadata?.resource || task.details || "resources");
+  const tool = normalizeItemName(task?.metadata?.tool || "axe");
+  const backupTools = Array.isArray(task?.metadata?.backupTools)
+    ? task.metadata.backupTools.map(normalizeItemName)
+    : [];
+  const targetDescription = describeTarget(task.target);
+  const storage = normalizeItemName(task?.metadata?.storage || "storage chest");
+  const quantity = resolveQuantity(task?.metadata?.quantity ?? task?.metadata?.count, null);
+  const method = normalizeItemName(task?.metadata?.method || "manual harvest");
+  const replant = task?.metadata?.replant ?? resource.includes("crop");
+  const replantItem = replant
+    ? normalizeItemName(task?.metadata?.replantItem || task?.metadata?.seed || `${resource} seeds`)
+    : null;
+  const harvestWindow = task?.metadata?.window || task?.metadata?.timing;
+  const maturity = task?.metadata?.maturity || (resource.includes("crop") ? "fully grown" : null);
+  const fieldSize = resolveQuantity(task?.metadata?.fieldSize, null);
+  const yieldPerPlot = resolveQuantity(task?.metadata?.yieldPerPlot, null);
+  const processing = Array.isArray(task?.metadata?.processing)
+    ? task.metadata.processing.map(normalizeItemName)
+    : [];
+
+  const inventory = extractInventory(context);
+  const hasPrimaryTool = hasInventoryItem(inventory, tool);
+  const missingTools = [tool, ...backupTools].filter(name => !hasInventoryItem(inventory, name));
+  const needsReplantSupplies = replant && replantItem && !hasInventoryItem(inventory, replantItem, fieldSize || 1);
+
+  const prepDescription = missingTools.length > 0
+    ? `Obtain or craft tools before departing: ${formatRequirementList(missingTools)}.`
+    : `Check durability on ${[tool, ...backupTools].filter(Boolean).join(", ") || tool} before departing.`;
+
+  const steps = [];
+
+  steps.push(
+    createStep({
+      title: "Prepare gear",
+      type: "preparation",
+      description: prepDescription,
+      metadata: { tool, backupTools }
+    })
+  );
+
+  if (needsReplantSupplies) {
+    steps.push(
+      createStep({
+        title: "Gather replanting stock",
+        type: "inventory",
+        description: `Restock ${replantItem} so fields can be replanted after harvesting.`,
+        metadata: { item: replantItem, amount: fieldSize || quantity || undefined }
+      })
+    );
+  }
+
+  if (task?.metadata?.supplies) {
+    const supplies = Array.isArray(task.metadata.supplies)
+      ? task.metadata.supplies
+      : Object.entries(task.metadata.supplies).map(([name, count]) => ({ name, count }));
+    const suppliesSummary = formatRequirementList(supplies) || "supportive items";
+    steps.push(
+      createStep({
+        title: "Pack supplies",
+        type: "inventory",
+        description: `Carry supportive items (${suppliesSummary}).`,
+        metadata: { supplies }
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Travel",
+      type: "movement",
+      description: `Head to ${targetDescription} where ${resource} can be collected.`,
+      metadata: { destination: targetDescription }
+    })
+  );
+
+  if (maturity || harvestWindow) {
+    const readinessDescriptionParts = [];
+    if (maturity) {
+      readinessDescriptionParts.push(`Confirm ${resource} are ${maturity}`);
+    }
+    if (harvestWindow) {
+      readinessDescriptionParts.push(`work within the preferred window (${harvestWindow})`);
+    }
+    const readinessDescription = readinessDescriptionParts.filter(Boolean).join(" and ") ||
+      `Inspect ${resource} plots and confirm readiness.`;
+    steps.push(
+      createStep({
+        title: "Inspect field",
+        type: "survey",
+        description: `${readinessDescription}.`,
+        metadata: { maturity, window: harvestWindow }
+      })
+    );
+  }
+
+  const harvestDescription = quantity
+    ? `Collect approximately ${quantity} ${resource} using the ${tool} via ${method}.`
+    : `Collect ${resource} efficiently using the ${tool} via ${method}.`;
+
+  steps.push(
+    createStep({
+      title: "Harvest",
+      type: "collection",
+      description: harvestDescription,
+      metadata: { tool, quantity, method }
+    })
+  );
+
+  if (replant) {
+    steps.push(
+      createStep({
+        title: "Replant",
+        type: "maintenance",
+        description: `Replant ${replantItem || "seeds or saplings"} to sustain future ${resource} harvests.`,
+        metadata: { item: replantItem || undefined }
+      })
+    );
+  }
+
+  if (processing.length > 0) {
+    steps.push(
+      createStep({
+        title: "Process yield",
+        type: "processing",
+        description: `Process gathered items (${processing.join(", ")}), such as composting extras or crafting blocks.`,
+        metadata: { processing }
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Sort",
+      type: "inventory",
+      description: `Organize gathered ${resource} in inventory, converting to blocks or bundles if useful.`
+    })
+  );
+
+  steps.push(
+    createStep({
+      title: "Store",
+      type: "storage",
+      description: `Deliver ${resource} to the ${storage} and update counts.`,
+      metadata: { container: storage, quantity }
+    })
+  );
+
+  if (task?.metadata?.compostExtras) {
+    steps.push(
+      createStep({
+        title: "Compost surplus",
+        type: "processing",
+        description: `Convert excess or spoiled ${resource} into bone meal before closing out the run.`,
+        metadata: { method: "compost" }
+      })
+    );
+  }
+
+  if (task?.metadata?.report !== false) {
+    steps.push(
+      createStep({
+        title: "Report",
+        type: "report",
+        description: `Share totals gathered and note regrowth timers or hazards encountered.`
+      })
+    );
+  }
+
+  const estimatedDuration = 9000 + (quantity ? quantity * 250 : 3500);
+  const resources = [
+    resource,
+    tool,
+    ...backupTools.filter(Boolean),
+    ...(replantItem ? [replantItem] : [])
+  ];
+  const uniqueResources = [...new Set(resources.filter(name => name && name !== "unspecified item"))];
+
+  const risks = [];
+  if (!hasPrimaryTool) {
+    risks.push(`Missing primary tool (${tool}) could slow gathering.`);
+  }
+  if (needsReplantSupplies) {
+    risks.push(`Insufficient ${replantItem} to fully replant after harvesting.`);
+  }
+  if (task?.metadata?.hostileRisk) {
+    risks.push("Hostile mobs may spawn during gathering.");
+  }
+
+  const notes = [];
+  if (task?.metadata?.weatherSensitive) {
+    notes.push("Avoid harvesting during rain to protect crops.");
+  }
+  if (task?.metadata?.schedule) {
+    notes.push(`Preferred harvest schedule: ${task.metadata.schedule}.`);
+  }
+  if (harvestWindow) {
+    notes.push(`Aim to harvest during ${harvestWindow} for peak yields.`);
+  }
+  if (fieldSize) {
+    const estimatedYield = yieldPerPlot && fieldSize && !quantity
+      ? yieldPerPlot * fieldSize
+      : quantity;
+    if (estimatedYield) {
+      notes.push(`Expect roughly ${estimatedYield} items from ${fieldSize} plots.`);
+    } else {
+      notes.push(`Field area covers approximately ${fieldSize} plots.`);
+    }
+  }
+
+  return createPlan({
+    task,
+    summary: `Gather ${resource} at ${targetDescription}.`,
+    steps,
+    estimatedDuration,
+    resources: uniqueResources,
+    risks,
+    notes
+  });
+}

--- a/tasks/plan_guard.js
+++ b/tasks/plan_guard.js
@@ -1,0 +1,177 @@
+// tasks/plan_guard.js
+// Planning logic for guarding or defensive assignments
+
+import {
+  createPlan,
+  createStep,
+  describeTarget,
+  normalizeItemName,
+  extractInventory,
+  hasInventoryItem,
+  formatRequirementList,
+  resolveQuantity
+} from "./helpers.js";
+
+export function planGuardTask(task, context = {}) {
+  const targetDescription = describeTarget(task.target);
+  const patrolRoute = Array.isArray(task?.metadata?.patrol)
+    ? task.metadata.patrol.map(point => describeTarget(point))
+    : [];
+  const shiftDuration = resolveQuantity(task?.metadata?.duration ?? task?.metadata?.shift, null);
+  const backup = normalizeItemName(task?.metadata?.support || "");
+  const alarm = normalizeItemName(task?.metadata?.alarm || "bell");
+  const stance = normalizeItemName(task?.metadata?.stance || "defensive");
+
+  const equipment = [
+    normalizeItemName(task?.metadata?.primaryWeapon || "sword"),
+    normalizeItemName(task?.metadata?.secondaryWeapon || "shield"),
+    "armor"
+  ].filter(Boolean);
+
+  const inventory = extractInventory(context);
+  const missingEquipment = equipment.filter(item => !hasInventoryItem(inventory, item));
+
+  const steps = [];
+
+  const missingEquipmentSummary = formatRequirementList(missingEquipment);
+  const equipDescription = missingEquipment.length > 0
+    ? missingEquipmentSummary
+      ? `Acquire missing equipment (${missingEquipmentSummary}) before heading out.`
+      : "Acquire missing equipment before heading out."
+    : `Equip ${equipment.join(", ")} before heading out.`;
+
+  steps.push(
+    createStep({
+      title: "Equip gear",
+      type: "preparation",
+      description: equipDescription,
+      metadata: { equipment, missing: missingEquipment }
+    })
+  );
+
+  if (task?.metadata?.potions) {
+    const potions = Array.isArray(task.metadata.potions)
+      ? task.metadata.potions.map(normalizeItemName)
+      : [normalizeItemName(task.metadata.potions)];
+    steps.push(
+      createStep({
+        title: "Brew buffs",
+        type: "preparation",
+        description: `Carry helpful potions (${potions.join(", ")}) for prolonged engagements.`,
+        metadata: { potions }
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Move to post",
+      type: "movement",
+      description: `Travel to guard position at ${targetDescription}.`,
+      metadata: { stance }
+    })
+  );
+
+  if (task?.metadata?.fortify) {
+    steps.push(
+      createStep({
+        title: "Fortify area",
+        type: "construction",
+        description: `Place defensive blocks, lighting, and traps as requested before starting the watch.`,
+        metadata: { fortify: task.metadata.fortify }
+      })
+    );
+  }
+
+  if (patrolRoute.length > 0) {
+    steps.push(
+      createStep({
+        title: "Patrol",
+        type: "action",
+        description: `Follow patrol route: ${patrolRoute.join(" -> ")}, watching for hostile mobs.`,
+        metadata: { route: patrolRoute }
+      })
+    );
+  } else {
+    steps.push(
+      createStep({
+        title: "Hold position",
+        type: "action",
+        description: `Monitor the area around ${targetDescription} and engage threats as necessary.`
+      })
+    );
+  }
+
+  if (shiftDuration && shiftDuration > 0) {
+    steps.push(
+      createStep({
+        title: "Maintain watch",
+        type: "timed",
+        description: `Maintain ${stance} stance for ${shiftDuration} minutes, rotating patrol cycles as needed.`,
+        metadata: { duration: shiftDuration }
+      })
+    );
+  }
+
+  if (backup && backup !== "unspecified item") {
+    steps.push(
+      createStep({
+        title: "Coordinate backup",
+        type: "communication",
+        description: `Stay in contact with ${backup} for reinforcements or relief.`,
+        metadata: { backup }
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Set alarm",
+      type: "preparation",
+      description: `Ensure alarm mechanism (${alarm}) is functional for quick alerts.`,
+      metadata: { alarm }
+    })
+  );
+
+  steps.push(
+    createStep({
+      title: "Report",
+      type: "report",
+      description: `Communicate status updates or threats detected while on guard duty.`,
+      metadata: { cadence: task?.metadata?.reportCadence || "regular" }
+    })
+  );
+
+  const estimatedDuration = 10000 + (shiftDuration ? shiftDuration * 600 : 4000);
+  const resources = [
+    ...new Set(
+      [...equipment, backup, alarm].filter(name => name && name !== "unspecified item")
+    )
+  ];
+
+  const risks = [];
+  if (missingEquipment.length > 0) {
+    risks.push("Guard may be under-equipped for threats.");
+  }
+  if (task?.metadata?.highThreat) {
+    risks.push("High threat level expected; keep escape route ready.");
+  }
+
+  const notes = [];
+  if (task?.metadata?.rotation) {
+    notes.push(`Guard rotation: ${task.metadata.rotation}.`);
+  }
+  if (task?.metadata?.safeZone) {
+    notes.push(`Fallback point: ${describeTarget(task.metadata.safeZone)}.`);
+  }
+
+  return createPlan({
+    task,
+    summary: `Guard ${targetDescription} with regular status updates.`,
+    steps,
+    estimatedDuration,
+    resources,
+    risks,
+    notes
+  });
+}

--- a/tasks/plan_interact.js
+++ b/tasks/plan_interact.js
@@ -1,0 +1,180 @@
+// tasks/plan_interact.js
+// Handles container or block interaction tasks like opening chests
+
+import {
+  createPlan,
+  createStep,
+  describeTarget,
+  normalizeItemName,
+  extractInventory,
+  hasInventoryItem,
+  formatRequirementList
+} from "./helpers.js";
+
+function normalizeTransferItems(transfer) {
+  if (!transfer) {
+    return { take: [], store: [] };
+  }
+  const normalizeEntry = entry => {
+    if (typeof entry === "string") {
+      return { name: normalizeItemName(entry) };
+    }
+    if (entry && typeof entry === "object") {
+      return {
+        name: normalizeItemName(entry.name || entry.item),
+        count: entry.count || entry.quantity
+      };
+    }
+    return null;
+  };
+
+  const take = Array.isArray(transfer.take)
+    ? transfer.take.map(normalizeEntry).filter(Boolean)
+    : transfer.take
+    ? [normalizeEntry(transfer.take)].filter(Boolean)
+    : [];
+  const store = Array.isArray(transfer.store)
+    ? transfer.store.map(normalizeEntry).filter(Boolean)
+    : transfer.store
+    ? [normalizeEntry(transfer.store)].filter(Boolean)
+    : [];
+
+  return { take, store };
+}
+
+export function planInteractTask(task, context = {}) {
+  const container = normalizeItemName(task?.metadata?.container || task?.metadata?.block || "chest");
+  const interaction = normalizeItemName(task?.metadata?.interaction || "open_container");
+  const targetDescription = describeTarget(task.target);
+  const transferRaw = task?.metadata?.transfer || {};
+  const transfer = normalizeTransferItems(transferRaw);
+  const requiresKey = normalizeItemName(task?.metadata?.requiresKey || "");
+  const holdItem = normalizeItemName(task?.metadata?.holdItem || "");
+  const duration = task?.metadata?.duration ? Number(task.metadata.duration) : null;
+
+  const inventory = extractInventory(context);
+  const missingKey = requiresKey && !hasInventoryItem(inventory, requiresKey);
+
+  const steps = [];
+
+  if (requiresKey) {
+    steps.push(
+      createStep({
+        title: "Prepare key",
+        type: "preparation",
+        description: missingKey
+          ? `Retrieve the ${requiresKey} required to unlock the ${container}.`
+          : `Keep the ${requiresKey} ready to unlock the ${container}.`,
+        metadata: { key: requiresKey }
+      })
+    );
+  }
+
+  if (holdItem && holdItem !== "unspecified item") {
+    steps.push(
+      createStep({
+        title: "Select tool",
+        type: "preparation",
+        description: `Hold ${holdItem} before interacting to trigger the correct behavior.`,
+        metadata: { item: holdItem }
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Approach",
+      type: "movement",
+      description: `Move to ${container} located at ${targetDescription}.`
+    })
+  );
+
+  const interactDescription = duration
+    ? `Perform ${interaction} on the ${container} and keep it open for ${duration} seconds to complete transfers.`
+    : `Perform ${interaction} on the ${container}, ensuring the inventory GUI remains open long enough for transfers.`;
+
+  const commandTarget =
+    task?.target && typeof task.target === "object" &&
+    Number.isFinite(task.target.x) &&
+    Number.isFinite(task.target.y) &&
+    Number.isFinite(task.target.z)
+      ? `${task.target.x} ${task.target.y} ${task.target.z}`
+      : targetDescription.replace(/[()]/g, "");
+
+  steps.push(
+    createStep({
+      title: "Interact",
+      type: "interaction",
+      description: interactDescription,
+      command: `/data get block ${commandTarget} Items`
+    })
+  );
+
+  if (transfer.take.length > 0 || transfer.store.length > 0) {
+    const transferParts = [];
+    if (transfer.take.length > 0) {
+      transferParts.push(`retrieve ${formatRequirementList(transfer.take)}`);
+    }
+    if (transfer.store.length > 0) {
+      transferParts.push(`deposit ${formatRequirementList(transfer.store)}`);
+    }
+
+    steps.push(
+      createStep({
+        title: "Manage inventory",
+        type: "inventory",
+        description: `Within the ${container}, ${transferParts.join(" and ")}. Confirm slot counts afterwards.`,
+        metadata: transfer
+      })
+    );
+  }
+
+  if (task?.metadata?.recordContents) {
+    steps.push(
+      createStep({
+        title: "Record contents",
+        type: "report",
+        description: `Log notable items inside the ${container} for tracking.`
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Secure container",
+      type: "cleanup",
+      description: `Close the ${container} and ensure no items spill on the ground.`
+    })
+  );
+
+  const resources = [container];
+  if (requiresKey && requiresKey !== "unspecified item") {
+    resources.push(requiresKey);
+  }
+  if (holdItem && holdItem !== "unspecified item") {
+    resources.push(holdItem);
+  }
+
+  const risks = [];
+  if (missingKey) {
+    risks.push(`Missing required key item (${requiresKey}).`);
+  }
+  if (task?.metadata?.redstoneLinked) {
+    risks.push("Redstone linkage may trigger traps when opened.");
+  }
+
+  const notes = [];
+  if (task?.metadata?.ownership) {
+    notes.push(`Container owned by ${task.metadata.ownership}; ensure permissions before interacting.`);
+  }
+
+  return createPlan({
+    task,
+    summary: `Interact with ${container} at ${targetDescription}.`,
+    steps,
+    estimatedDuration: duration ? duration * 1000 + 3000 : 7000,
+    resources,
+    risks,
+    notes
+  });
+}

--- a/tasks/plan_mine.js
+++ b/tasks/plan_mine.js
@@ -1,0 +1,301 @@
+// tasks/plan_mine.js
+// Generates a sequence for mining style tasks
+
+import {
+  createPlan,
+  createStep,
+  describeTarget,
+  normalizeItemName,
+  extractInventory,
+  hasInventoryItem,
+  countInventoryItems,
+  formatRequirementList,
+  resolveQuantity
+} from "./helpers.js";
+
+const DEFAULT_SUPPORT_SUPPLIES = [
+  { name: "torch", count: 32 },
+  { name: "wood", count: 16 },
+  { name: "food", count: 8 }
+];
+
+function determineSupportSupplies(task) {
+  const extras = Array.isArray(task?.metadata?.supplies) ? task.metadata.supplies : [];
+  const normalizedExtras = extras
+    .map(item => {
+      if (typeof item === "string") {
+        return { name: normalizeItemName(item) };
+      }
+      if (item && typeof item === "object") {
+        return {
+          name: normalizeItemName(item.name || item.item),
+          count: resolveQuantity(item.count ?? item.quantity, null)
+        };
+      }
+      return null;
+    })
+    .filter(Boolean);
+
+  return [...DEFAULT_SUPPORT_SUPPLIES, ...normalizedExtras];
+}
+
+export function planMineTask(task, context = {}) {
+  const targetDescription = describeTarget(task.target);
+  const resource = normalizeItemName(task?.metadata?.resource || task?.metadata?.ore || task.details);
+  const tool = normalizeItemName(task?.metadata?.tool || "pickaxe");
+  const backupTool = normalizeItemName(task?.metadata?.backupTool || task?.metadata?.secondaryTool || "");
+  const dropOff = task?.metadata?.dropOff ? normalizeItemName(task.metadata.dropOff) : null;
+  const quantity = resolveQuantity(task?.metadata?.quantity ?? task?.metadata?.count, null);
+  const depth = resolveQuantity(task?.metadata?.depth ?? task?.metadata?.yLevel, null);
+  const hazards = Array.isArray(task?.metadata?.hazards) ? task.metadata.hazards.map(normalizeItemName) : [];
+  const miningMethod = normalizeItemName(task?.metadata?.method || "branch");
+  const reinforcements = Array.isArray(task?.metadata?.reinforcements)
+    ? task.metadata.reinforcements.map(item => {
+        if (typeof item === "string") {
+          return { name: normalizeItemName(item) };
+        }
+        if (item && typeof item === "object") {
+          return {
+            name: normalizeItemName(item.name || item.item),
+            count: resolveQuantity(item.count ?? item.quantity, null)
+          };
+        }
+        return null;
+      }).filter(Boolean)
+    : [];
+  const anchorPoint = task?.metadata?.anchorPoint || task?.metadata?.respawnAnchor;
+  const escort = task?.metadata?.escort;
+
+  const inventory = extractInventory(context);
+  const supportSupplies = determineSupportSupplies(task);
+  const missingSupport = supportSupplies.filter(item => {
+    if (!item?.name) {
+      return false;
+    }
+    if (item.count) {
+      return !hasInventoryItem(inventory, item.name, item.count);
+    }
+    return !hasInventoryItem(inventory, item.name, 1);
+  });
+
+  const hasPrimaryTool = hasInventoryItem(inventory, tool);
+  const hasBackupTool = backupTool ? hasInventoryItem(inventory, backupTool) : true;
+  const toolStepDescription = hasPrimaryTool
+    ? `Inspect ${tool} durability and equip it before entering the mine.`
+    : `Retrieve or craft a suitable ${tool} before entering the mine.`;
+
+  const steps = [];
+
+  const missingSupportSummary = formatRequirementList(missingSupport);
+  const supportSummary = formatRequirementList(supportSupplies) || "support supplies";
+
+  steps.push(
+    createStep({
+      title: "Stock supplies",
+      type: "inventory",
+      description:
+        missingSupport.length > 0
+          ? missingSupportSummary
+            ? `Restock essential supplies (${missingSupportSummary}).`
+            : "Restock essential supplies before descending."
+          : `Confirm support supplies are packed: ${supportSummary}.`,
+      metadata: { supplies: supportSupplies, missing: missingSupport }
+    })
+  );
+
+  if (reinforcements.length > 0) {
+    const reinforcementSummary = formatRequirementList(reinforcements) || "reinforcement blocks";
+    steps.push(
+      createStep({
+        title: "Stage reinforcements",
+        type: "preparation",
+        description: `Pack building blocks for shoring: ${reinforcementSummary}.`,
+        metadata: { reinforcements }
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Gear check",
+      type: "preparation",
+      description: toolStepDescription,
+      metadata: {
+        tool,
+        backupTool: backupTool || undefined
+      }
+    })
+  );
+
+  steps.push(
+    createStep({
+      title: "Navigate",
+      type: "movement",
+      description: `Travel to ${targetDescription} using safe pathing, lighting dark areas en route.`
+    })
+  );
+
+  if (anchorPoint || hasInventoryItem(inventory, "bed")) {
+    steps.push(
+      createStep({
+        title: "Secure exit",
+        type: "safety",
+        description: anchorPoint
+          ? `Set spawn or anchor at ${anchorPoint} and mark a clear return path.`
+          : "Place a temporary bed near the mine entrance and mark the route back.",
+        metadata: { anchor: anchorPoint || (hasInventoryItem(inventory, "bed") ? "bed" : undefined) }
+      })
+    );
+  }
+
+  if (escort) {
+    steps.push(
+      createStep({
+        title: "Coordinate escort",
+        type: "coordination",
+        description: `Meet with ${escort} before descent and assign overwatch positions.`,
+        metadata: { escort }
+      })
+    );
+  }
+
+  if (depth && depth < 20) {
+    steps.push(
+      createStep({
+        title: "Stabilize shaft",
+        type: "safety",
+        description: `Install support beams and ladder access while descending to Y${depth}.`
+      })
+    );
+  }
+
+  if (hazards.includes("lava") || hazards.includes("lava pool")) {
+    steps.push(
+      createStep({
+        title: "Mitigate lava",
+        type: "safety",
+        description: "Carry a water bucket or fire resistance potion and block off exposed lava before mining."
+      })
+    );
+  }
+
+  const miningDescription = quantity
+    ? `Mine approximately ${quantity} blocks of ${resource} using ${miningMethod} tunnels.`
+    : `Mine the ${resource} using ${miningMethod} tunnels, reinforcing ceilings and sealing hazards.`;
+
+  steps.push(
+    createStep({
+      title: "Mine",
+      type: "action",
+      description: miningDescription,
+      metadata: { method: miningMethod, quantity }
+    })
+  );
+
+  if (reinforcements.length > 0) {
+    steps.push(
+      createStep({
+        title: "Shore tunnels",
+        type: "safety",
+        description: "Place reinforcement blocks along long corridors and above exposed ceilings as you mine.",
+        metadata: { reinforcements }
+      })
+    );
+  }
+
+  if (task?.metadata?.requiresSilkTouch) {
+    steps.push(
+      createStep({
+        title: "Apply silk touch",
+        type: "quality",
+        description: `Use a silk touch tool on ${resource} blocks that should stay intact.`
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Collect drops",
+      type: "collection",
+      description: `Collect the dropped items and ensure inventory space for ${resource}.`
+    })
+  );
+
+  const oreCount = countInventoryItems(inventory, resource);
+  const shouldSmelt = task?.metadata?.autoSmelt || resource.includes("ore");
+
+  if (shouldSmelt) {
+    steps.push(
+      createStep({
+        title: "Process ore",
+        type: "processing",
+        description: `Smelt or blast ${resource} at a furnace array before storage if time allows.`,
+        metadata: { smelt: true }
+      })
+    );
+  }
+
+  if (dropOff) {
+    steps.push(
+      createStep({
+        title: "Store resources",
+        type: "storage",
+        description: `Deliver the mined ${resource} to the ${dropOff} and tidy the mining shaft for future runs.`,
+        metadata: { container: dropOff }
+      })
+    );
+  }
+
+  steps.push(
+    createStep({
+      title: "Log findings",
+      type: "report",
+      description: `Report yields (${oreCount} currently on hand) and note any hazards or new branches discovered.`
+    })
+  );
+
+  const estimatedDuration = 11000 + (quantity ? quantity * 500 : 4000);
+  const resources = [resource, tool]
+    .concat(supportSupplies.map(item => item.name))
+    .concat(reinforcements.map(item => item.name))
+    .filter(Boolean);
+  const uniqueResources = [...new Set(resources.filter(name => name && name !== "unspecified item"))];
+
+  const risks = [];
+  if (hazards.includes("cave")) {
+    risks.push("Unlit caves may spawn hostile mobs.");
+  }
+  if (hazards.includes("gravel")) {
+    risks.push("Falling gravel or sand could suffocate the miner.");
+  }
+  if (!hasBackupTool && backupTool) {
+    risks.push(`No functional backup ${backupTool} is available if the primary breaks.`);
+  }
+  if (reinforcements.length === 0 && (hazards.includes("ravine") || hazards.includes("unstable ceiling"))) {
+    risks.push("Lack of reinforcement blocks increases collapse risk.");
+  }
+
+  const notes = [];
+  if (task?.metadata?.beacon) {
+    notes.push(`Activate haste beacon at ${task.metadata.beacon}.`);
+  }
+  if (task?.metadata?.chunkBoundary) {
+    notes.push(`Stay within chunk ${task.metadata.chunkBoundary} to avoid missing the lode.`);
+  }
+  if (reinforcements.length > 0) {
+    notes.push("Use staged reinforcements to seal side tunnels once depleted.");
+  }
+  if (escort) {
+    notes.push(`Escort ${escort} provides backup; maintain line-of-sight while mining.`);
+  }
+
+  return createPlan({
+    task,
+    summary: `Mine ${resource} at ${targetDescription}.`,
+    steps,
+    estimatedDuration,
+    resources: uniqueResources,
+    risks,
+    notes
+  });
+}


### PR DESCRIPTION
## Summary
- extend the gather planner with crop readiness surveys, replant stock handling, composting, and richer notes
- add reinforcement logistics, anchor handling, and escort coordination to the mining planner for safer excursions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f69e0c7da0832db2ebae49e5c0087e