### PR TITLE
Refine NPC identity management and spawning

### DIFF
--- a/data/npc_profiles.json
+++ b/data/npc_profiles.json
@@ -1,0 +1,25 @@
+{
+  "miner_01": {
+    "skills": {
+      "mining": 5,
+      "building": 2,
+      "gathering": 3,
+      "exploring": 2,
+      "guard": 1
+    },
+    "personality": {
+      "curiosity": 0.72,
+      "patience": 0.58,
+      "motivation": 0.81,
+      "empathy": 0.41,
+      "aggression": 0.23,
+      "creativity": 0.36,
+      "loyalty": 0.77
+    },
+    "xp": 12,
+    "tasksCompleted": 12,
+    "tasksFailed": 1,
+    "lastActivity": "2024-01-05T12:00:00.000Z",
+    "createdAt": "2024-01-01T00:00:00.000Z"
+  }
+}

--- a/data/npc_registry.json
+++ b/data/npc_registry.json
@@ -1,0 +1,68 @@
+{
+  "version": 1,
+  "updatedAt": "2024-01-01T00:00:00.000Z",
+  "npcs": [
+    {
+      "id": "miner_01",
+      "npcType": "miner",
+      "role": "miner",
+      "appearance": {
+        "skin": "default",
+        "outfit": "overalls"
+      },
+      "spawnPosition": {
+        "x": 100,
+        "y": 65,
+        "z": 200
+      },
+      "lastKnownPosition": {
+        "x": 100,
+        "y": 65,
+        "z": 200
+      },
+      "personality": {
+        "curiosity": 0.72,
+        "patience": 0.58,
+        "motivation": 0.81,
+        "empathy": 0.41,
+        "aggression": 0.23,
+        "creativity": 0.36,
+        "loyalty": 0.77
+      },
+      "personalitySummary": "neutral",
+      "personalityTraits": [
+        "Loves exploring and discovering new things",
+        "Eager to work and improve",
+        "Extremely loyal and dependable"
+      ],
+      "metadata": {
+        "description": "Primary tunnel excavator",
+        "personalitySummary": "neutral",
+        "personalityTraits": [
+          "Loves exploring and discovering new things",
+          "Eager to work and improve",
+          "Extremely loyal and dependable"
+        ],
+        "learning": {
+          "xp": 12,
+          "tasksCompleted": 12,
+          "tasksFailed": 1,
+          "skills": {
+            "mining": 5,
+            "building": 2,
+            "gathering": 3,
+            "exploring": 2,
+            "guard": 1
+          }
+        }
+      },
+      "description": "Primary tunnel excavator",
+      "status": "active",
+      "spawnCount": 0,
+      "lastSpawnedAt": null,
+      "lastDespawnedAt": null,
+      "createdAt": "2024-01-01T00:00:00.000Z",
+      "updatedAt": "2024-01-01T00:00:00.000Z"
+    }
+  ]
+}

--- a/minecraft_bridge.js
+++ b/minecraft_bridge.js
@@ -137,6 +137,26 @@ export class MinecraftBridge extends EventEmitter {
     }
   ];
 
+const EQUIPMENT_SLOT_ALIASES = Object.freeze({
+  head: "armor.head",
+  helmet: "armor.head",
+  hat: "armor.head",
+  chest: "armor.chest",
+  chestplate: "armor.chest",
+  torso: "armor.chest",
+  legs: "armor.legs",
+  leggings: "armor.legs",
+  pants: "armor.legs",
+  feet: "armor.feet",
+  boots: "armor.feet",
+  shoes: "armor.feet",
+  mainhand: "weapon.mainhand",
+  hand: "weapon.mainhand",
+  weapon: "weapon.mainhand",
+  offhand: "weapon.offhand",
+  shield: "weapon.offhand"
+});
+
   /**
    * Creates a new MinecraftBridge instance
    * @param {Object} options - Configuration options
@@ -173,6 +193,8 @@ export class MinecraftBridge extends EventEmitter {
    * @param {Object} [options.commandTemplates={}] - Command template functions
    * @param {Object} [options.spawnEntityMapping={}] - Entity type to Minecraft ID mapping
    * @param {Function} [options.spawnCommandFormatter=null] - Custom spawn command formatter
+   * @param {Function} [options.appearanceFormatter=null] - Custom appearance command formatter
+   * @param {number} [options.appearanceCommandDelay=200] - Delay (ms) before applying appearance commands
    * @param {Array<string>} [options.friendlyIds=[]] - List of friendly entity IDs
    * @param {Function} [options.isFriendly=null] - Custom friendly check function
    */
@@ -231,7 +253,11 @@ export class MinecraftBridge extends EventEmitter {
         fighter: "minecraft:iron_golem",
         ...options.spawnEntityMapping
       },
-      spawnCommandFormatter: options.spawnCommandFormatter || null
+      spawnCommandFormatter: options.spawnCommandFormatter || null,
+      appearanceFormatter: options.appearanceFormatter || null,
+      appearanceCommandDelay: typeof options.appearanceCommandDelay === "number" && options.appearanceCommandDelay >= 0
+        ? options.appearanceCommandDelay
+        : 200
     };
   }
 
@@ -910,9 +936,12 @@ export class MinecraftBridge extends EventEmitter {
    * @param {string} params.npcId - NPC identifier
    * @param {string} params.npcType - NPC type
    * @param {Object} params.position - Position {x, y, z}
+   * @param {Object} [params.appearance] - Appearance configuration to apply post-spawn
+   * @param {Object} [params.metadata] - Additional metadata about the NPC
+   * @param {Object} [params.profile] - Profile context for the NPC
    * @returns {Promise<string>} Server response
    */
-  async spawnEntity({ npcId, npcType, position }) {
+  async spawnEntity({ npcId, npcType, position, appearance, metadata, profile }) {
     await this.ensureConnected();
 
     const entityId = this.options.spawnEntityMapping?.[npcType] ||
@@ -931,8 +960,253 @@ export class MinecraftBridge extends EventEmitter {
     }
 
     const response = await this.sendRawCommand(command);
-    this.emit("npc_spawned", { npcId, npcType, command, response });
+
+    let appearanceResponses = null;
+    if (appearance && typeof appearance === "object" && Object.keys(appearance).length > 0) {
+      appearanceResponses = await this.applyNpcAppearance({
+        npcId,
+        npcType,
+        appearance,
+        metadata,
+        profile
+      });
+    }
+
+    this.emit("npc_spawned", {
+      npcId,
+      npcType,
+      position,
+      command,
+      response,
+      appearance,
+      metadata,
+      profile,
+      appearanceResponses
+    });
+
     return response;
+  }
+
+  /**
+   * Applies post-spawn appearance customizations for an NPC
+   * @param {Object} params - Appearance parameters
+   * @param {string} params.npcId - NPC identifier
+   * @param {string} params.npcType - NPC type
+   * @param {Object} params.appearance - Appearance definition
+   * @param {Object} [params.metadata] - Additional NPC metadata
+   * @param {Object} [params.profile] - Registry profile for additional context
+   * @returns {Promise<Array<string>|null>} Responses from executed commands, if any
+   */
+  async applyNpcAppearance({ npcId, npcType, appearance, metadata, profile }) {
+    if (!npcId || !appearance || typeof appearance !== "object") {
+      return null;
+    }
+
+    const commands = [];
+
+    if (typeof this.options.appearanceFormatter === "function") {
+      try {
+        const formatted = await this.options.appearanceFormatter({
+          npcId,
+          npcType,
+          appearance,
+          metadata,
+          profile,
+          bridge: this
+        });
+
+        if (Array.isArray(formatted)) {
+          for (const command of formatted) {
+            if (typeof command === "string" && command.trim().length > 0) {
+              commands.push(command.trim());
+            }
+          }
+        } else if (typeof formatted === "string" && formatted.trim().length > 0) {
+          commands.push(formatted.trim());
+        } else if (formatted && typeof formatted === "object" && Array.isArray(formatted.commands)) {
+          for (const command of formatted.commands) {
+            if (typeof command === "string" && command.trim().length > 0) {
+              commands.push(command.trim());
+            }
+          }
+        }
+      } catch (error) {
+        console.error(`❌ appearanceFormatter failed for ${npcId}:`, error.message);
+      }
+    }
+
+    const fallbackCommands = this._buildAppearanceCommands({ npcId, appearance, metadata, profile });
+    if (fallbackCommands.length > 0) {
+      commands.push(...fallbackCommands);
+    }
+
+    if (commands.length === 0) {
+      return null;
+    }
+
+    if (this.options.appearanceCommandDelay > 0) {
+      await this._delay(this.options.appearanceCommandDelay);
+    }
+
+    const responses = [];
+    for (const command of commands) {
+      try {
+        const response = await this.sendCommand(command);
+        responses.push(response);
+      } catch (error) {
+        console.error(`❌ Failed to apply appearance command for ${npcId}:`, error.message);
+      }
+    }
+
+    return responses;
+  }
+
+  _buildAppearanceCommands({ npcId, appearance }) {
+    if (!appearance || typeof appearance !== "object") {
+      return [];
+    }
+
+    const commandList = [];
+
+    const manualCommands = Array.isArray(appearance.commands)
+      ? appearance.commands
+      : typeof appearance.command === "string"
+        ? [appearance.command]
+        : [];
+
+    for (const command of manualCommands) {
+      if (typeof command === "string" && command.trim().length > 0) {
+        commandList.push(command.trim());
+      }
+    }
+
+    if (appearance.equipment) {
+      const equipment = appearance.equipment;
+
+      if (Array.isArray(equipment)) {
+        for (const entry of equipment) {
+          if (Array.isArray(entry) && entry.length >= 2) {
+            const [slotKey, itemDef] = entry;
+            const command = this._formatEquipmentCommand(npcId, slotKey, itemDef);
+            if (command) {
+              commandList.push(command);
+            }
+            continue;
+          }
+
+          if (entry && typeof entry === "object") {
+            const slotKey = entry.slot || entry.position || entry.type;
+            const command = this._formatEquipmentCommand(npcId, slotKey, entry.item ?? entry.id ?? entry.name ?? entry);
+            if (command) {
+              commandList.push(command);
+            }
+          }
+        }
+      } else if (typeof equipment === "object") {
+        for (const [slotKey, itemDef] of Object.entries(equipment)) {
+          const command = this._formatEquipmentCommand(npcId, slotKey, itemDef);
+          if (command) {
+            commandList.push(command);
+          }
+        }
+      }
+    }
+
+    if (Array.isArray(appearance.effects)) {
+      for (const effect of appearance.effects) {
+        if (!effect || typeof effect !== "object") {
+          continue;
+        }
+        const effectId = effect.id || effect.effect || effect.type;
+        if (!effectId) {
+          continue;
+        }
+
+        const duration = Number.isFinite(effect.duration)
+          ? Math.max(1, Math.floor(effect.duration))
+          : 120;
+        const amplifier = Number.isFinite(effect.amplifier)
+          ? Math.max(0, Math.floor(effect.amplifier))
+          : 0;
+        const hideParticles = effect.showParticles === false;
+
+        let command = `effect give ${npcId} ${this._normalizeNamespacedId(effectId, "minecraft")}`;
+        command += ` ${duration}`;
+        command += ` ${amplifier}`;
+        if (hideParticles) {
+          command += " true";
+        }
+        commandList.push(command);
+      }
+    }
+
+    return commandList;
+  }
+
+  _formatEquipmentCommand(npcId, slotKey, itemDef) {
+    if (!slotKey) {
+      return null;
+    }
+
+    const normalizedSlotKey = typeof slotKey === "string" ? slotKey.toLowerCase() : "";
+    const slot = EQUIPMENT_SLOT_ALIASES[normalizedSlotKey] || slotKey;
+    if (typeof slot !== "string" || slot.length === 0) {
+      return null;
+    }
+
+    let itemId = null;
+    let count = 1;
+    let nbt = null;
+
+    if (typeof itemDef === "string") {
+      itemId = itemDef;
+    } else if (itemDef && typeof itemDef === "object") {
+      itemId = itemDef.id || itemDef.item || itemDef.name || null;
+      if (Number.isFinite(itemDef.count)) {
+        count = Math.max(1, Math.min(64, Math.floor(itemDef.count)));
+      }
+      if (typeof itemDef.nbt === "string" && itemDef.nbt.trim().length > 0) {
+        nbt = itemDef.nbt.trim();
+      }
+    } else {
+      return null;
+    }
+
+    const namespacedId = this._normalizeNamespacedId(itemId, "minecraft");
+    if (!namespacedId) {
+      return null;
+    }
+
+    let command = `item replace entity ${npcId} ${slot} with ${namespacedId}`;
+    if (Number.isFinite(count) && count > 1) {
+      command += ` ${count}`;
+    }
+    if (nbt) {
+      const formattedNbt = nbt.startsWith("{") ? nbt : `{${nbt}}`;
+      command += ` ${formattedNbt}`;
+    }
+    return command;
+  }
+
+  _normalizeNamespacedId(id, namespace = "minecraft") {
+    if (!id || typeof id !== "string") {
+      return null;
+    }
+    const trimmed = id.trim();
+    if (trimmed.length === 0) {
+      return null;
+    }
+    if (trimmed.includes(":")) {
+      return trimmed;
+    }
+    return `${namespace}:${trimmed}`;
+  }
+
+  async _delay(ms) {
+    if (!Number.isFinite(ms) || ms <= 0) {
+      return;
+    }
+    await new Promise(resolve => setTimeout(resolve, ms));
   }
 
   /**

--- a/npc_engine/bridge.js
+++ b/npc_engine/bridge.js
@@ -117,19 +117,31 @@ export class BridgeManager {
    * @param {string} id - NPC ID
    * @returns {Promise<any>} Bridge response
    */
-  async spawnNPC(id) {
+  async spawnNPC(id, options = {}) {
     if (!this.engine.bridge) {
       console.warn(`⚠️  Cannot spawn NPC ${id} without an active bridge connection.`);
       return null;
     }
 
     const npc = this.engine.npcs.get(id);
-    if (!npc) {
+    if (!npc && !options.npcType) {
       console.warn(`⚠️  Attempted to spawn unknown NPC ${id}`);
       return null;
     }
 
-    const position = npc.position || this.engine.defaultSpawnPosition;
-    return this.engine.bridge.spawnEntity({ npcId: id, npcType: npc.type, position });
+    const npcType = options.npcType || npc?.type || "builder";
+    const position = options.position || npc?.position || this.engine.defaultSpawnPosition;
+    const appearance = options.appearance || npc?.appearance || npc?.profile?.appearance || {};
+    const metadata = options.metadata || npc?.metadata || npc?.profile?.metadata || {};
+    const profile = options.profile || npc?.profile || null;
+
+    return this.engine.bridge.spawnEntity({
+      npcId: id,
+      npcType,
+      position,
+      appearance,
+      metadata,
+      profile
+    });
   }
 }

--- a/npc_identity.js
+++ b/npc_identity.js
@@ -1,0 +1,144 @@
+import { Traits } from "./traits.js";
+
+export function ensureTraitsHelper(traitsHelper) {
+  if (
+    traitsHelper &&
+    typeof traitsHelper.getDetailedDescription === "function" &&
+    typeof traitsHelper.generate === "function"
+  ) {
+    return traitsHelper;
+  }
+  return new Traits();
+}
+
+export function cloneValue(value) {
+  if (value == null || typeof value !== "object") {
+    return value ?? null;
+  }
+  if (Array.isArray(value)) {
+    return value.map(cloneValue);
+  }
+  return { ...value };
+}
+
+export function buildPersonalityBundle(personality, traitsHelper) {
+  const helper = ensureTraitsHelper(traitsHelper);
+  let finalPersonality = null;
+
+  if (personality && typeof personality === "object") {
+    const isValid = helper.isValidPersonality
+      ? helper.isValidPersonality(personality)
+      : true;
+    if (isValid) {
+      finalPersonality = { ...personality };
+    }
+  }
+
+  if (!finalPersonality) {
+    finalPersonality = helper.generate();
+  }
+
+  const details = helper.getDetailedDescription(finalPersonality);
+  return {
+    personality: finalPersonality,
+    summary: details.summary,
+    traits: Array.isArray(details.traits) ? [...details.traits] : [],
+  };
+}
+
+export function applyPersonalityMetadata(metadata, bundle) {
+  const result = metadata ? { ...metadata } : {};
+  if (bundle?.summary) {
+    result.personalitySummary = bundle.summary;
+  }
+  if (bundle?.traits) {
+    result.personalityTraits = Array.isArray(bundle.traits)
+      ? [...bundle.traits]
+      : bundle.traits;
+  }
+  return result;
+}
+
+export function deriveLearningEnrichment(learningProfile, traitsHelper) {
+  if (!learningProfile || typeof learningProfile !== "object") {
+    return {
+      learningMetadata: null,
+      personality: null,
+      personalitySummary: null,
+      personalityTraits: null,
+    };
+  }
+
+  const enrichment = {
+    learningMetadata: {
+      xp: learningProfile.xp ?? 0,
+      tasksCompleted: learningProfile.tasksCompleted ?? 0,
+      tasksFailed: learningProfile.tasksFailed ?? 0,
+      skills: learningProfile.skills ? { ...learningProfile.skills } : {},
+    },
+    personality: null,
+    personalitySummary: null,
+    personalityTraits: null,
+  };
+
+  if (learningProfile.personality) {
+    const bundle = buildPersonalityBundle(
+      learningProfile.personality,
+      traitsHelper
+    );
+    enrichment.personality = bundle.personality;
+    enrichment.personalitySummary = bundle.summary;
+    enrichment.personalityTraits = bundle.traits;
+  }
+
+  return enrichment;
+}
+
+export function mergeLearningIntoProfile(profile, learningProfile, traitsHelper) {
+  if (!learningProfile) {
+    return { ...profile };
+  }
+
+  const enrichment = deriveLearningEnrichment(learningProfile, traitsHelper);
+  const metadata = profile.metadata ? { ...profile.metadata } : {};
+
+  if (enrichment.learningMetadata) {
+    metadata.learning = enrichment.learningMetadata;
+  }
+
+  const merged = {
+    ...profile,
+    metadata,
+  };
+
+  if (enrichment.personality) {
+    merged.personality = enrichment.personality;
+  }
+  if (enrichment.personalitySummary) {
+    merged.personalitySummary = enrichment.personalitySummary;
+  }
+  if (enrichment.personalityTraits) {
+    merged.personalityTraits = enrichment.personalityTraits;
+  }
+
+  merged.metadata = applyPersonalityMetadata(merged.metadata, {
+    summary: merged.personalitySummary ?? profile.personalitySummary,
+    traits: merged.personalityTraits ?? profile.personalityTraits,
+  });
+
+  return merged;
+}
+
+export function serializeRegistryEntry(entry) {
+  return {
+    ...entry,
+    personality: cloneValue(entry.personality),
+    appearance: cloneValue(entry.appearance),
+    metadata: cloneValue(entry.metadata),
+    spawnPosition: cloneValue(entry.spawnPosition),
+    lastKnownPosition: cloneValue(entry.lastKnownPosition),
+    personalityTraits: Array.isArray(entry.personalityTraits)
+      ? [...entry.personalityTraits]
+      : [],
+  };
+}

--- a/npc_profile.schema.json
+++ b/npc_profile.schema.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/schemas/npc_profile.schema.json",
+  "title": "NPC Profile Registry",
+  "type": "object",
+  "additionalProperties": {
+    "type": "object",
+    "properties": {
+      "skills": {
+        "type": "object",
+        "properties": {
+          "mining": { "type": "number", "minimum": 0 },
+          "building": { "type": "number", "minimum": 0 },
+          "gathering": { "type": "number", "minimum": 0 },
+          "exploring": { "type": "number", "minimum": 0 },
+          "guard": { "type": "number", "minimum": 0 }
+        },
+        "additionalProperties": false,
+        "required": ["mining", "building", "gathering", "exploring", "guard"]
+      },
+      "personality": {
+        "type": "object",
+        "properties": {
+          "curiosity": { "type": "number", "minimum": 0, "maximum": 1 },
+          "patience": { "type": "number", "minimum": 0, "maximum": 1 },
+          "motivation": { "type": "number", "minimum": 0, "maximum": 1 },
+          "empathy": { "type": "number", "minimum": 0, "maximum": 1 },
+          "aggression": { "type": "number", "minimum": 0, "maximum": 1 },
+          "creativity": { "type": "number", "minimum": 0, "maximum": 1 },
+          "loyalty": { "type": "number", "minimum": 0, "maximum": 1 }
+        },
+        "required": ["curiosity", "patience", "motivation", "empathy", "aggression", "creativity", "loyalty"],
+        "additionalProperties": false
+      },
+      "xp": { "type": "number", "minimum": 0 },
+      "tasksCompleted": { "type": "number", "minimum": 0 },
+      "tasksFailed": { "type": "number", "minimum": 0 },
+      "lastActivity": { "type": ["string", "null"], "format": "date-time" },
+      "createdAt": { "type": "string", "format": "date-time" }
+    },
+    "required": [
+      "skills",
+      "personality",
+      "xp",
+      "tasksCompleted",
+      "tasksFailed",
+      "createdAt"
+    ],
+    "additionalProperties": true
+  }
+}

--- a/npc_registry.js
+++ b/npc_registry.js
@@ -1,0 +1,350 @@
+import { promises as fs } from "fs";
+import path from "path";
+import { fileURLToPath } from "url";
+
+import {
+  applyPersonalityMetadata,
+  buildPersonalityBundle,
+  cloneValue,
+  ensureTraitsHelper,
+  serializeRegistryEntry
+} from "./npc_identity.js";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const DEFAULT_REGISTRY_PATH = path.join(__dirname, "data", "npc_registry.json");
+
+/**
+ * Persistent registry for NPC identities, roles and traits.
+ */
+export class NPCRegistry {
+  constructor(options = {}) {
+    this.registryPath = options.registryPath || DEFAULT_REGISTRY_PATH;
+    this.traits = ensureTraitsHelper(options.traitsGenerator);
+    this.npcs = new Map();
+    this.loaded = false;
+    this.saveQueue = Promise.resolve();
+  }
+
+  async load() {
+    if (this.loaded) {
+      return this.getAll();
+    }
+
+    try {
+      const data = await fs.readFile(this.registryPath, "utf8");
+      const parsed = JSON.parse(data);
+      const entries = Array.isArray(parsed?.npcs) ? parsed.npcs : [];
+      this.npcs.clear();
+      for (const entry of entries) {
+        if (entry?.id) {
+          this.npcs.set(entry.id, this._normalizeEntry(entry));
+        }
+      }
+      this.loaded = true;
+      return this.getAll();
+    } catch (error) {
+      if (error.code === "ENOENT") {
+        await this.save();
+        this.loaded = true;
+        return this.getAll();
+      }
+      throw error;
+    }
+  }
+
+  async save() {
+    if (!this.loaded) {
+      this.loaded = true;
+    }
+    return this._enqueueSave();
+  }
+
+  getAll() {
+    return [...this.npcs.values()].map(entry => ({ ...entry }));
+  }
+
+  get(id) {
+    if (!id) return null;
+    const entry = this.npcs.get(id);
+    return entry ? { ...entry } : null;
+  }
+
+  async ensureProfile(options = {}) {
+    await this.load();
+
+    const {
+      id,
+      baseName,
+      role,
+      npcType,
+      appearance,
+      personality,
+      spawnPosition,
+      metadata,
+      description
+    } = options;
+
+    if (id && this.npcs.has(id)) {
+      return this._mergeEntry(id, {
+        role,
+        npcType,
+        appearance,
+        personality,
+        spawnPosition,
+        metadata,
+        description
+      });
+    }
+
+    const generatedId = id || this._generateId(baseName || role || npcType || "NPC");
+    const profile = this._buildProfile({
+      id: generatedId,
+      role,
+      npcType,
+      appearance,
+      personality,
+      spawnPosition,
+      metadata,
+      description
+    });
+    this.npcs.set(profile.id, profile);
+    await this.save();
+    return { ...profile };
+  }
+
+  async upsert(profile) {
+    if (!profile?.id) {
+      throw new Error("Cannot upsert NPC profile without an id");
+    }
+    await this.load();
+    const normalized = this._buildProfile(profile, true);
+    this.npcs.set(normalized.id, normalized);
+    await this.save();
+    return { ...normalized };
+  }
+
+  async markInactive(id) {
+    if (!id) return null;
+    return this.recordDespawn(id, { status: "inactive" });
+  }
+
+  async recordSpawn(id, position, options = {}) {
+    if (!id) return null;
+    await this.load();
+    const existing = this.npcs.get(id);
+    if (!existing) {
+      throw new Error(`Cannot record spawn for unknown NPC id ${id}`);
+    }
+
+    const now = new Date().toISOString();
+    const shouldIncrement = options.increment !== false;
+    const parsedCount = Number(existing.spawnCount);
+    const baseCount = Number.isFinite(parsedCount) ? parsedCount : 0;
+    const updated = {
+      ...existing,
+      spawnCount: Math.max(0, baseCount) + (shouldIncrement ? 1 : 0),
+      lastSpawnedAt: shouldIncrement ? now : existing.lastSpawnedAt || null,
+      lastKnownPosition: cloneValue(position)
+        || cloneValue(existing.lastKnownPosition)
+        || cloneValue(existing.spawnPosition)
+        || null,
+      status: options.status || "active",
+      updatedAt: now
+    };
+
+    this.npcs.set(id, updated);
+    await this.save();
+    return { ...updated };
+  }
+
+  async recordDespawn(id, options = {}) {
+    if (!id) return null;
+    await this.load();
+    const existing = this.npcs.get(id);
+    if (!existing) {
+      return null;
+    }
+
+    const now = new Date().toISOString();
+    const updated = {
+      ...existing,
+      status: options.status || "inactive",
+      lastDespawnedAt: now,
+      lastKnownPosition: cloneValue(options.position)
+        || cloneValue(existing.lastKnownPosition)
+        || cloneValue(existing.spawnPosition)
+        || null,
+      updatedAt: now
+    };
+
+    this.npcs.set(id, updated);
+    await this.save();
+    return { ...updated };
+  }
+
+  listActive() {
+    return this.getAll().filter(entry => entry.status !== "inactive");
+  }
+
+  _generateId(baseName) {
+    const sanitized = String(baseName || "NPC")
+      .replace(/[^A-Za-z0-9]+/g, "_")
+      .replace(/^_+|_+$/g, "")
+      .replace(/_{2,}/g, "_")
+      .toLowerCase();
+
+    const prefix = sanitized.length > 0 ? sanitized : "npc";
+    let counter = 1;
+    let candidate;
+    do {
+      const suffix = counter < 10 ? `0${counter}` : String(counter);
+      candidate = `${prefix}_${suffix}`;
+      counter++;
+    } while (this.npcs.has(candidate));
+    return candidate;
+  }
+
+  _buildProfile(profile, allowMissingId = false) {
+    if (!allowMissingId && !profile?.id) {
+      throw new Error("NPC profile must include an id");
+    }
+
+    const id = profile.id || this._generateId(profile.baseName || profile.role || profile.npcType);
+    const npcType = profile.npcType || profile.type || "builder";
+    const role = profile.role || npcType;
+
+    const bundle = buildPersonalityBundle(profile.personality, this.traits);
+    const existingMetadata = this.npcs.get(id)?.metadata;
+    const baseMetadata =
+      profile.metadata != null
+        ? cloneValue(profile.metadata)
+        : existingMetadata != null
+          ? cloneValue(existingMetadata)
+          : {};
+    const metadata = applyPersonalityMetadata(baseMetadata, bundle);
+
+    const now = new Date().toISOString();
+    const existing = this.npcs.get(id);
+
+    return {
+      id,
+      npcType,
+      role,
+      appearance: cloneValue(profile.appearance)
+        || (existing ? cloneValue(existing.appearance) : {}),
+      spawnPosition: cloneValue(profile.spawnPosition)
+        || (existing ? cloneValue(existing.spawnPosition) : null),
+      lastKnownPosition: cloneValue(profile.lastKnownPosition)
+        || (existing ? cloneValue(existing.lastKnownPosition) : null),
+      personality: bundle.personality,
+      personalitySummary: bundle.summary,
+      personalityTraits: bundle.traits,
+      metadata,
+      description: profile.description || existing?.description || null,
+      status: profile.status || existing?.status || "active",
+      spawnCount: typeof profile.spawnCount === "number"
+        ? profile.spawnCount
+        : typeof existing?.spawnCount === "number"
+          ? existing.spawnCount
+          : 0,
+      lastSpawnedAt: profile.lastSpawnedAt || existing?.lastSpawnedAt || null,
+      lastDespawnedAt: profile.lastDespawnedAt || existing?.lastDespawnedAt || null,
+      createdAt: existing?.createdAt || now,
+      updatedAt: now
+    };
+  }
+
+  _mergeEntry(id, updates) {
+    const existing = this.npcs.get(id);
+    if (!existing) {
+      throw new Error(`Cannot merge NPC profile for unknown id ${id}`);
+    }
+    const merged = {
+      ...existing,
+      ...this._buildProfile({
+        id,
+        npcType: updates.npcType || existing.npcType,
+        role: updates.role || existing.role,
+        appearance: updates.appearance || existing.appearance,
+        spawnPosition: updates.spawnPosition || existing.spawnPosition,
+        personality: updates.personality || existing.personality,
+        metadata: updates.metadata || existing.metadata,
+        description: updates.description || existing.description,
+        spawnCount: typeof updates.spawnCount === "number" ? updates.spawnCount : existing.spawnCount,
+        lastSpawnedAt: updates.lastSpawnedAt || existing.lastSpawnedAt,
+        lastDespawnedAt: updates.lastDespawnedAt || existing.lastDespawnedAt,
+        lastKnownPosition: updates.lastKnownPosition || existing.lastKnownPosition,
+        status: existing.status
+      }, true)
+    };
+    this.npcs.set(id, merged);
+    this.save().catch(err => {
+      console.error(`❌ Failed to save NPC registry for ${id}:`, err.message);
+    });
+    return { ...merged };
+  }
+
+  _normalizeEntry(entry) {
+    const bundle = buildPersonalityBundle(entry.personality, this.traits);
+
+    return {
+      id: entry.id,
+      npcType: entry.npcType || entry.type || "builder",
+      role: entry.role || entry.npcType || entry.type || "builder",
+      appearance: cloneValue(entry.appearance) || {},
+      spawnPosition: cloneValue(entry.spawnPosition) || null,
+      lastKnownPosition:
+        cloneValue(entry.lastKnownPosition)
+        || cloneValue(entry.spawnPosition)
+        || null,
+      personality: bundle.personality,
+      personalitySummary:
+        typeof entry.personalitySummary === "string"
+          ? entry.personalitySummary
+          : bundle.summary,
+      personalityTraits: Array.isArray(entry.personalityTraits)
+        ? [...entry.personalityTraits]
+        : bundle.traits,
+      metadata: applyPersonalityMetadata(cloneValue(entry.metadata), {
+        summary:
+          typeof entry.personalitySummary === "string"
+            ? entry.personalitySummary
+            : bundle.summary,
+        traits: Array.isArray(entry.personalityTraits)
+          ? [...entry.personalityTraits]
+          : bundle.traits
+      }),
+      description: entry.description || null,
+      status: entry.status || "active",
+      spawnCount: typeof entry.spawnCount === "number" ? entry.spawnCount : 0,
+      lastSpawnedAt: entry.lastSpawnedAt || null,
+      lastDespawnedAt: entry.lastDespawnedAt || null,
+      createdAt: entry.createdAt || new Date().toISOString(),
+      updatedAt: entry.updatedAt || new Date().toISOString()
+    };
+  }
+
+  async _enqueueSave() {
+    this.loaded = true;
+    const run = async () => {
+      const payload = this._serialize();
+      await fs.mkdir(path.dirname(this.registryPath), { recursive: true });
+      const serialized = JSON.stringify(payload, null, 2);
+      await fs.writeFile(this.registryPath, serialized, "utf8");
+      return payload;
+    };
+
+    const scheduled = this.saveQueue.then(run);
+    this.saveQueue = scheduled.catch(() => {});
+    return scheduled;
+  }
+
+  _serialize() {
+    return {
+      version: 1,
+      updatedAt: new Date().toISOString(),
+      npcs: [...this.npcs.values()].map(serializeRegistryEntry)
+    };
+  }
+}

--- a/npc_spawner.js
+++ b/npc_spawner.js
@@ -1,0 +1,244 @@
+import { NPCRegistry } from "./npc_registry.js";
+import { LearningEngine } from "./learning_engine.js";
+import {
+  applyPersonalityMetadata,
+  buildPersonalityBundle,
+  cloneValue,
+  mergeLearningIntoProfile
+} from "./npc_identity.js";
+
+/**
+ * Coordinates NPC profile creation, engine registration and in-world spawning.
+ */
+export class NPCSpawner {
+  constructor(options = {}) {
+    this.engine = options.engine || null;
+    this.bridge = options.bridge || this.engine?.bridge || null;
+    if (options.registry instanceof NPCRegistry) {
+      this.registry = options.registry;
+    } else if (options.registry === null || options.registry === false) {
+      this.registry = null;
+    } else {
+      this.registry = new NPCRegistry(options.registryOptions);
+    }
+    this.autoSpawn = options.autoSpawn ?? this.engine?.autoSpawn ?? true;
+    this.defaultPosition = options.defaultPosition || this.engine?.defaultSpawnPosition || { x: 0, y: 64, z: 0 };
+    this.registryReady = null;
+    this.learningEngine = options.learningEngine instanceof LearningEngine
+      ? options.learningEngine
+      : this.engine?.learningEngine instanceof LearningEngine
+        ? this.engine.learningEngine
+        : null;
+    this.learningReady = this.engine?.learningReady || null;
+  }
+
+  async initialize() {
+    if (!this.registryReady && this.registry) {
+      this.registryReady = this.registry.load().catch(err => {
+        console.error("❌ Failed to load NPC registry:", err.message);
+        throw err;
+      });
+    }
+    if (!this.learningReady && this.learningEngine) {
+      this.learningReady = this.learningEngine.initialize().catch(err => {
+        console.error("❌ Failed to initialize learning engine:", err.message);
+        throw err;
+      });
+    }
+
+    const readiness = [this.registryReady, this.learningReady].filter(Boolean);
+    if (readiness.length === 0) {
+      return Promise.resolve();
+    }
+    return Promise.all(readiness);
+  }
+
+  async spawn(options = {}) {
+    await this.initialize();
+
+    const desiredPosition = options.position || options.spawnPosition || this.defaultPosition;
+
+    let profile = await this._resolveProfile(options, desiredPosition);
+
+    if (this.learningEngine) {
+      try {
+        await (this.learningReady || Promise.resolve());
+        const learningProfile = this.learningEngine.getProfile(profile.id);
+        if (learningProfile) {
+          const enriched = mergeLearningIntoProfile(
+            profile,
+            learningProfile,
+            this.learningEngine.traits
+          );
+          if (this.registry) {
+            profile = await this.registry.upsert(enriched);
+          } else {
+            profile = enriched;
+          }
+        }
+      } catch (error) {
+        console.error(`⚠️  Failed to merge learning profile for NPC ${profile.id}:`, error.message);
+      }
+    }
+
+    const position = desiredPosition || profile.spawnPosition || this.defaultPosition;
+
+    this._registerWithEngine(profile, position, options);
+
+    const shouldSpawn = (options.autoSpawn ?? this.autoSpawn) && (this.engine?.bridge || this.bridge);
+    let spawnResponse = null;
+
+    if (shouldSpawn) {
+      try {
+        spawnResponse = await (this.engine?.spawnNPC?.(profile.id, {
+          npcType: profile.npcType,
+          position,
+          appearance: profile.appearance,
+          metadata: profile.metadata,
+          profile
+        }) || this.bridge?.spawnEntity({
+          npcId: profile.id,
+          npcType: profile.npcType,
+          position,
+          appearance: profile.appearance,
+          metadata: profile.metadata,
+          profile
+        }));
+      } catch (error) {
+        console.error(`❌ Failed to spawn NPC ${profile.id}:`, error.message);
+      }
+    }
+
+    return this._finalizeSpawn(profile, position, {
+      spawnResponse,
+      shouldSpawn
+    });
+  }
+
+  async spawnAllKnown(options = {}) {
+    await this.initialize();
+    const npcs = this.registry
+      ? this.registry.listActive()
+      : [];
+    const results = [];
+    for (const profile of npcs) {
+      const merged = {
+        ...profile,
+        ...options.overrides,
+        position: options.overrides?.position || profile.spawnPosition || this.defaultPosition,
+        autoSpawn: options.autoSpawn
+      };
+      const result = await this.spawn(merged);
+      results.push(result);
+    }
+    return results;
+  }
+
+  async _resolveProfile(options, desiredPosition) {
+    if (this.registry) {
+      return this.registry.ensureProfile({
+        id: options.id,
+        baseName: options.baseName,
+        role: options.role,
+        npcType: options.npcType || options.type,
+        appearance: options.appearance,
+        personality: options.personality,
+        spawnPosition: desiredPosition,
+        metadata: options.metadata,
+        description: options.description
+      });
+    }
+
+    const id = options.id || options.baseName || `npc_${Date.now()}`;
+    const npcType = options.npcType || options.type || "builder";
+    const role = options.role || npcType;
+    const bundle = buildPersonalityBundle(options.personality, this.learningEngine?.traits);
+
+    return {
+      id,
+      npcType,
+      role,
+      appearance: cloneValue(options.appearance) || {},
+      spawnPosition: desiredPosition,
+      personality: bundle.personality,
+      personalitySummary: bundle.summary,
+      personalityTraits: bundle.traits,
+      metadata: applyPersonalityMetadata(cloneValue(options.metadata) || {}, bundle),
+      description: options.description || null
+    };
+  }
+
+  _registerWithEngine(profile, position, options) {
+    if (!this.engine) {
+      return;
+    }
+
+    this.engine.registerNPC(profile.id, profile.npcType, {
+      position,
+      role: profile.role,
+      personality: profile.personality,
+      appearance: profile.appearance,
+      metadata: {
+        ...profile.metadata,
+        description: profile.description,
+        personalitySummary: profile.personalitySummary,
+        personalityTraits: Array.isArray(profile.personalityTraits)
+          ? [...profile.personalityTraits]
+          : profile.personalityTraits
+      },
+      profile,
+      personalitySummary: profile.personalitySummary,
+      personalityTraits: Array.isArray(profile.personalityTraits)
+        ? [...profile.personalityTraits]
+        : profile.personalityTraits,
+      autoSpawn: options.autoSpawn,
+      persist: options.persist
+    });
+  }
+
+  async _finalizeSpawn(profile, position, context) {
+    if (!this.registry) {
+      return {
+        ...profile,
+        lastSpawnResponse: context.spawnResponse
+      };
+    }
+
+    try {
+      const updatedProfile = await this.registry.recordSpawn(profile.id, position, {
+        increment: context.shouldSpawn,
+        status: "active"
+      });
+
+      if (this.engine?.npcs.has(profile.id)) {
+        const npcState = this.engine.npcs.get(profile.id);
+        npcState.profile = updatedProfile;
+        npcState.position = { ...position };
+        npcState.personalitySummary = updatedProfile.personalitySummary;
+        npcState.personalityTraits = Array.isArray(updatedProfile.personalityTraits)
+          ? [...updatedProfile.personalityTraits]
+          : updatedProfile.personalityTraits;
+        npcState.metadata = {
+          ...npcState.metadata,
+          description: updatedProfile.description ?? npcState.metadata?.description,
+          personalitySummary: updatedProfile.personalitySummary,
+          personalityTraits: Array.isArray(updatedProfile.personalityTraits)
+            ? [...updatedProfile.personalityTraits]
+            : updatedProfile.personalityTraits
+        };
+      }
+
+      return {
+        ...updatedProfile,
+        lastSpawnResponse: context.spawnResponse
+      };
+    } catch (error) {
+      console.error(`❌ Failed to update registry for NPC ${profile.id}:`, error.message);
+    }
+
+    return {
+      ...profile,
+      lastSpawnResponse: context.spawnResponse
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- add a shared npc_identity helper to centralize personality description, learning enrichment, and serialization utilities
- rework the NPC registry and spawner to use the shared helpers, improve metadata cloning, and queue persistence writes safely
- streamline NPCEngine registration and learning sync logic to reuse the shared identity helpers and maintain consistent metadata when hydrating NPCs

## Testing
- node --input-type=module -e "import { NPCEngine } from './npc_engine.js'; const engine = new NPCEngine({ autoSpawn: false, bridge: null }); await Promise.all([engine.registryReady, engine.learningReady]); const profile = await engine.createNPC({ id: 'miner_01', autoSpawn: false, persist: false }); console.log(profile.id, profile.personalitySummary, profile.metadata.learning?.xp); console.log(JSON.stringify(engine.getStatus(), null, 2));"
- node --input-type=module -e "import { NPCEngine } from './npc_engine.js'; const engine = new NPCEngine({ autoSpawn: false }); await Promise.all([engine.registryReady, engine.learningReady]); const created = await engine.createNPC({ baseName: 'ScoutAlpha', role: 'scout', npcType: 'scout', autoSpawn: false, persist: false }); console.log(created.id, created.personalitySummary, created.metadata.learning);"

------
https://chatgpt.com/codex/tasks/task_e_6902ceef40d4832da0173f1c39683d10