### PR TITLE
Fix start-server.bat crashing issue

### DIFF
--- a/start-server.bat
+++ b/start-server.bat
@@ -86,6 +86,8 @@ where node >nul 2>&1
 if %errorlevel% neq 0 (
     call :print_error "Node.js is not installed"
     echo   Please install Node.js from https://nodejs.org/
+    echo.
+    pause
     exit /b 1
 )
 
@@ -96,6 +98,8 @@ REM Extract major version (remove 'v' and get first number)
 for /f "tokens=1 delims=." %%a in ("%NODE_VERSION:~1%") do set "MAJOR_VERSION=%%a"
 if %MAJOR_VERSION% lss 14 (
     call :print_error "Node.js version 14.x or higher required (found %NODE_VERSION%)"
+    echo.
+    pause
     exit /b 1
 )
 
@@ -103,6 +107,8 @@ REM Check npm
 where npm >nul 2>&1
 if %errorlevel% neq 0 (
     call :print_error "npm is not installed"
+    echo.
+    pause
     exit /b 1
 )
 
@@ -112,6 +118,8 @@ call :print_success "npm installed: v%NPM_VERSION%"
 REM Check package.json
 if not exist "package.json" (
     call :print_error "package.json not found in %CD%"
+    echo.
+    pause
     exit /b 1
 )
 call :print_success "package.json found"
@@ -119,6 +127,8 @@ call :print_success "package.json found"
 REM Check server.js
 if not exist "server.js" (
     call :print_error "server.js not found in %CD%"
+    echo.
+    pause
     exit /b 1
 )
 call :print_success "server.js found"
@@ -130,6 +140,8 @@ if "%SKIP_INSTALL%"=="false" (
         call npm install
         if %errorlevel% neq 0 (
             call :print_error "Failed to install dependencies"
+            echo.
+            pause
             exit /b 1
         )
         call :print_success "Dependencies installed"
@@ -189,6 +201,8 @@ if /i "%MODE%"=="test" goto :start_test
 
 call :print_error "Invalid mode: %MODE%"
 echo Valid modes: prod, dev, test
+echo.
+pause
 exit /b 1
 
 :start_prod
@@ -208,6 +222,8 @@ call :print_info "Running tests..."
 echo.
 if not exist "test\npc_system.test.js" (
     call :print_error "Test file not found"
+    echo.
+    pause
     exit /b 1
 )
 node test\npc_system.test.js
@@ -263,4 +279,12 @@ echo [94mi[0m %~1
 goto :eof
 
 :end
+if %errorlevel% neq 0 (
+    echo.
+    echo ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    echo   Server exited with errors
+    echo ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+    echo.
+    pause
+)
 endlocal


### PR DESCRIPTION
The batch file was closing immediately on errors, preventing users from seeing what went wrong. This re-adds the pause commands that were removed in commit a1d38fd.

Changes:
- Add pause before all exit /b 1 commands to keep window open on errors
- Add error handling in :end section to catch server crashes
- Show clear "Server exited with errors" message when failures occur

This fixes the issue where start-server.bat would crash and close immediately, leaving users unable to diagnose the problem.