### PR TITLE
Fix missing export in model director module

### DIFF
--- a/npc_engine/autonomy.js
+++ b/npc_engine/autonomy.js
@@ -1,7 +1,7 @@
 // npc_engine/autonomy.js
 // AI-driven autonomous task generation and management
 
-import { generateModelTasks, DEFAULT_AUTONOMY_PROMPT_TEXT } from "../model_director.js";
+import { generateModelTasks, DEFAULT_AUTONOMY_PROMPT } from "../model_director.js";
 import { validateTask } from "../task_schema.js";
 import { cloneTask } from "./utils.js";
 
@@ -24,7 +24,7 @@ export class AutonomyManager {
     this.disableModelAutonomy();
 
     const {
-      instructions = DEFAULT_AUTONOMY_PROMPT_TEXT,
+      instructions = DEFAULT_AUTONOMY_PROMPT,
       intervalMs = 10000,
       maxTasks = 3,
       allowWhenBusy = false,


### PR DESCRIPTION
Fixed SyntaxError where autonomy.js was importing DEFAULT_AUTONOMY_PROMPT_TEXT but model_director.js exports it as DEFAULT_AUTONOMY_PROMPT. Updated both the import statement and the variable reference to use the correct export name.