### PR TITLE
Add auto-login with local API key

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -22,8 +22,9 @@ JWT_SECRET=
 JWT_EXPIRES_IN=24h
 
 # API Keys for different user roles
+# Default API key for local development: folks123
 # These should be changed in production
-ADMIN_API_KEY=admin-key-change-me
+ADMIN_API_KEY=folks123
 LLM_API_KEY=llm-key-change-me
 
 # Minecraft RCON Configuration (Optional)

--- a/admin.js
+++ b/admin.js
@@ -5,11 +5,29 @@ let apiKey = "";
 let socket = null;
 let refreshTimeout = null;
 
-document.addEventListener("DOMContentLoaded", () => {
-  apiKey = localStorage.getItem("apiKey") || "";
+document.addEventListener("DOMContentLoaded", async () => {
+  // Auto-login with default API key for local development
+  const DEFAULT_API_KEY = "folks123";
+  apiKey = localStorage.getItem("apiKey") || DEFAULT_API_KEY;
+
   const apiKeyInput = document.getElementById("apiKeyInput");
-  if (apiKeyInput && apiKey) {
+  if (apiKeyInput) {
     apiKeyInput.value = apiKey;
+  }
+
+  // Auto-login if we have an API key
+  if (apiKey) {
+    try {
+      await login(apiKey);
+      console.log("Auto-login successful");
+    } catch (err) {
+      // If auto-login fails, show login screen
+      console.log("Auto-login failed, showing login screen");
+      apiKey = DEFAULT_API_KEY;
+      if (apiKeyInput) {
+        apiKeyInput.value = apiKey;
+      }
+    }
   }
 
   document.getElementById("loginForm").addEventListener("submit", handleLoginSubmit);

--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -18,7 +18,8 @@ export const ROLES = {
 };
 
 // Default users (in production, use a database)
-const ADMIN_API_KEY = resolveSecret('ADMIN_API_KEY', 'admin-key-change-me', { label: 'Admin API key' });
+// Default API key for local development: folks123
+const ADMIN_API_KEY = resolveSecret('ADMIN_API_KEY', 'folks123', { label: 'Admin API key' });
 const LLM_API_KEY = resolveSecret('LLM_API_KEY', 'llm-key-change-me', { label: 'LLM API key' });
 
 const USERS = {


### PR DESCRIPTION
- Set default ADMIN_API_KEY to 'folks123' for local development
- Implement auto-login in admin panel that automatically uses the API key
- Update .env.example to reflect the new default API key
- Admin panel will now auto-login on page load for seamless local development
- If auto-login fails, user is shown login screen with the default key pre-filled

This change makes local development easier by removing the need to manually enter the API key each time. The default key 'folks123' is used for all local/PC deployments.