### PR TITLE
Fix bot spawn and despawn actions

### DIFF
--- a/npc_engine.js
+++ b/npc_engine.js
@@ -747,6 +747,12 @@ export class NPCEngine extends EventEmitter {
       clearTimeout(this.taskTimeouts.get(id));
       this.taskTimeouts.delete(id);
     }
+    if (this.bridge?.despawnEntity) {
+      Promise.resolve(this.bridge.despawnEntity({ npcId: id })).catch(error => {
+        console.error(`⚠️  Failed to despawn NPC ${id}:`, error.message);
+      });
+    }
+
     this.npcs.delete(id);
     console.log(`👋 Unregistered NPC ${id}`);
     this.emit("npc_unregistered", { id });


### PR DESCRIPTION
## Summary
- auto-spawn new bots through the bot API when the bridge is available and enforce the spawn limit
- surface spawn results in the creation response for better client feedback
- trigger Minecraft despawn commands when NPCs are unregistered
- update the spawn integration test to match the current registry/spawner APIs so it runs successfully

## Testing
- node test_spawning.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690d4fd0be18832d8d0abb5a8bcb220d)