### PR TITLE
Follow-up: centralise tunables, coalesce state recompute, widen response envelope

### DIFF
--- a/middleware/auth.js
+++ b/middleware/auth.js
@@ -5,10 +5,11 @@ import jwt from 'jsonwebtoken';
 import crypto from 'crypto';
 import bcrypt from 'bcrypt';
 import { v4 as uuidv4 } from 'uuid';
+import { AUTH_LIMITS } from '../src/config/limits.js';
 
 // Generate a secure secret if not provided
 const JWT_SECRET = process.env.JWT_SECRET || crypto.randomBytes(64).toString('hex');
-const JWT_EXPIRES_IN = process.env.JWT_EXPIRES_IN || '1h';
+const JWT_EXPIRES_IN = AUTH_LIMITS.JWT_EXPIRES_IN;
 
 // Refresh token storage (still in-memory; move to Redis when refresh flow
 // is needed across restarts).
@@ -19,7 +20,7 @@ const refreshTokens = new Map();
 // when Redis is not configured or temporarily unavailable.
 const tokenBlacklist = new Set();
 const BLACKLIST_KEY_PREFIX = 'auth:blacklist:';
-const DEFAULT_BLACKLIST_TTL_SEC = 60 * 60; // 1 hour, matches default JWT TTL
+const DEFAULT_BLACKLIST_TTL_SEC = AUTH_LIMITS.BLACKLIST_TTL_SEC;
 let _redisClientPromise = null;
 
 async function getBlacklistRedisClient() {
@@ -63,7 +64,7 @@ async function isTokenBlacklisted(token) {
 }
 
 // Bcrypt configuration
-const SALT_ROUNDS = 12;
+const SALT_ROUNDS = AUTH_LIMITS.BCRYPT_SALT_ROUNDS;
 
 // User roles
 export const ROLES = {
@@ -177,7 +178,7 @@ export function generateTokens(user) {
   const refreshToken = uuidv4();
   refreshTokens.set(refreshToken, {
     userId: user.id,
-    expiresAt: Date.now() + 7 * 24 * 60 * 60 * 1000  // 7 days
+    expiresAt: Date.now() + AUTH_LIMITS.REFRESH_TOKEN_TTL_MS
   });
 
   return { accessToken, refreshToken };

--- a/routes/action.js
+++ b/routes/action.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { authenticate, authorize } from '../middleware/auth.js';
 import { createActionPipeline } from '../src/services/action_pipeline/index.js';
+import { fail } from '../src/middleware/response.js';
 
 export function initActionRoutes(npcSystem, io) {
   const router = express.Router();
@@ -19,7 +20,8 @@ export function initActionRoutes(npcSystem, io) {
         result: result.result || null,
       });
     } catch (err) {
-      res.status(400).json({ error: err.message || 'Action failed' });
+      const status = err?.status && err.status >= 400 && err.status < 600 ? err.status : 400;
+      return fail(res, status, err.message || 'Action failed');
     }
   });
 

--- a/routes/llm.js
+++ b/routes/llm.js
@@ -4,6 +4,7 @@
 import express from 'express';
 import { authenticate, authorize, ROLES } from '../middleware/auth.js';
 import { spawnBot, spawnAllBots } from '../src/services/spawn_pipeline.js';
+import { fail } from '../src/middleware/response.js';
 
 const router = express.Router();
 
@@ -312,10 +313,7 @@ export function initLLMRoutes(npcSystem, io) {
       const { command, context } = req.body;
 
       if (!command || typeof command !== 'string') {
-        return res.status(400).json({
-          error: 'Bad request',
-          message: 'Command must be a non-empty string',
-        });
+        return fail(res, 400, 'Bad request', 'Command must be a non-empty string');
       }
 
       console.log(`🤖 LLM command from ${req.user.username}: ${command}`);
@@ -340,10 +338,7 @@ export function initLLMRoutes(npcSystem, io) {
       }
     } catch (error) {
       console.error('Error executing LLM command:', error);
-      res.status(500).json({
-        error: 'Internal server error',
-        message: error.message,
-      });
+      return fail(res, 500, 'Internal server error', error.message);
     }
   });
 
@@ -356,10 +351,7 @@ export function initLLMRoutes(npcSystem, io) {
       const { commands } = req.body;
 
       if (!Array.isArray(commands)) {
-        return res.status(400).json({
-          error: 'Bad request',
-          message: 'Commands must be an array',
-        });
+        return fail(res, 400, 'Bad request', 'Commands must be an array');
       }
 
       console.log(`🤖 LLM batch (${commands.length} commands) from ${req.user.username}`);
@@ -395,10 +387,7 @@ export function initLLMRoutes(npcSystem, io) {
       });
     } catch (error) {
       console.error('Error executing LLM batch:', error);
-      res.status(500).json({
-        error: 'Internal server error',
-        message: error.message,
-      });
+      return fail(res, 500, 'Internal server error', error.message);
     }
   });
 

--- a/routes/minecraft_status.js
+++ b/routes/minecraft_status.js
@@ -2,6 +2,7 @@
 // Lightweight Minecraft bridge/plugin status endpoints
 
 import express from 'express';
+import { fail } from '../src/middleware/response.js';
 
 export function initMinecraftStatusRoutes(npcSystem) {
   const router = express.Router();
@@ -39,7 +40,7 @@ export function initMinecraftStatusRoutes(npcSystem) {
 
       res.json(status);
     } catch (err) {
-      res.status(500).json({ error: 'Failed to get Minecraft status', message: err.message });
+      return fail(res, 500, 'Failed to get Minecraft status', err.message);
     }
   });
 

--- a/src/api/autonomy.js
+++ b/src/api/autonomy.js
@@ -3,6 +3,7 @@
 
 import express from 'express';
 import { getLLMController } from '../autonomy/llm_controller.js';
+import { fail } from '../middleware/response.js';
 import {
     getBotTokenStats,
     getAggregateTokenStats,
@@ -26,17 +27,17 @@ export function initAutonomyRoutes(npcEngine, bridge) {
             const { botId, goal, options } = req.body;
 
             if (!botId || typeof botId !== 'string') {
-                return res.status(400).json({ error: 'botId is required' });
+                return fail(res, 400, 'botId is required');
             }
 
             if (!goal || typeof goal !== 'string') {
-                return res.status(400).json({ error: 'goal is required' });
+                return fail(res, 400, 'goal is required');
             }
 
             const result = await llmController.executeDecision(botId, goal, options || {});
 
             if (!result.success) {
-                return res.status(500).json({ error: result.error });
+                return fail(res, 500, result.error || 'LLM decision failed');
             }
 
             res.json({
@@ -50,7 +51,7 @@ export function initAutonomyRoutes(npcEngine, bridge) {
 
         } catch (err) {
             console.error('Autonomy goal error:', err);
-            res.status(500).json({ error: err.message });
+            return fail(res, 500, err.message);
         }
     });
 
@@ -63,7 +64,7 @@ export function initAutonomyRoutes(npcEngine, bridge) {
             const { botId, goal, interval, options } = req.body;
 
             if (!botId || typeof botId !== 'string') {
-                return res.status(400).json({ error: 'botId is required' });
+                return fail(res, 400, 'botId is required');
             }
 
             llmController.startAutonomousLoop(botId, {
@@ -81,7 +82,7 @@ export function initAutonomyRoutes(npcEngine, bridge) {
 
         } catch (err) {
             console.error('Start autonomy error:', err);
-            res.status(500).json({ error: err.message });
+            return fail(res, 500, err.message);
         }
     });
 
@@ -94,7 +95,7 @@ export function initAutonomyRoutes(npcEngine, bridge) {
             const { botId } = req.body;
 
             if (!botId || typeof botId !== 'string') {
-                return res.status(400).json({ error: 'botId is required' });
+                return fail(res, 400, 'botId is required');
             }
 
             llmController.stopAutonomousLoop(botId);
@@ -107,7 +108,7 @@ export function initAutonomyRoutes(npcEngine, bridge) {
 
         } catch (err) {
             console.error('Stop autonomy error:', err);
-            res.status(500).json({ error: err.message });
+            return fail(res, 500, err.message);
         }
     });
 
@@ -127,7 +128,7 @@ export function initAutonomyRoutes(npcEngine, bridge) {
 
         } catch (err) {
             console.error('Get stats error:', err);
-            res.status(500).json({ error: err.message });
+            return fail(res, 500, err.message);
         }
     });
 
@@ -141,7 +142,7 @@ export function initAutonomyRoutes(npcEngine, bridge) {
             const stats = getBotTokenStats(botId);
 
             if (!stats) {
-                return res.status(404).json({ error: `No statistics found for bot ${botId}` });
+                return fail(res, 404, `No statistics found for bot ${botId}`);
             }
 
             res.json({
@@ -151,7 +152,7 @@ export function initAutonomyRoutes(npcEngine, bridge) {
 
         } catch (err) {
             console.error('Get bot stats error:', err);
-            res.status(500).json({ error: err.message });
+            return fail(res, 500, err.message);
         }
     });
 
@@ -176,7 +177,7 @@ export function initAutonomyRoutes(npcEngine, bridge) {
 
         } catch (err) {
             console.error('Get history error:', err);
-            res.status(500).json({ error: err.message });
+            return fail(res, 500, err.message);
         }
     });
 
@@ -191,7 +192,7 @@ export function initAutonomyRoutes(npcEngine, bridge) {
 
         } catch (err) {
             console.error('Get metrics error:', err);
-            res.status(500).json({ error: err.message });
+            return fail(res, 500, err.message);
         }
     });
 
@@ -211,7 +212,7 @@ export function initAutonomyRoutes(npcEngine, bridge) {
 
         } catch (err) {
             console.error('Reset stats error:', err);
-            res.status(500).json({ error: err.message });
+            return fail(res, 500, err.message);
         }
     });
 

--- a/src/api/health.js
+++ b/src/api/health.js
@@ -2,6 +2,7 @@ import express from 'express';
 import { logger } from '../../logger.js';
 import { getServiceContainer, getServiceStatus } from '../services/service_container.js';
 import { getPool } from '../database/connection.js';
+import { fail } from '../middleware/response.js';
 
 /**
  * Initialize health check and metrics routes
@@ -122,7 +123,7 @@ export function initHealthRoutes(npcSystem, stateManager) {
       res.json(metrics);
     } catch (err) {
       logger.error('Failed to get system metrics', { error: err.message });
-      res.status(500).json({ error: 'Failed to retrieve metrics' });
+      return fail(res, 500, 'Failed to retrieve metrics', err.message);
     }
   });
 
@@ -132,14 +133,14 @@ export function initHealthRoutes(npcSystem, stateManager) {
   router.get('/autonomic', (req, res) => {
     try {
       if (!npcSystem.autonomicCore) {
-        return res.status(503).json({ error: 'Autonomic core not initialized' });
+        return fail(res, 503, 'Autonomic core not initialized');
       }
 
       const status = npcSystem.autonomicCore.getStatus();
       res.json(status);
     } catch (err) {
       logger.error('Failed to get autonomic status', { error: err.message });
-      res.status(500).json({ error: 'Failed to get autonomic status' });
+      return fail(res, 500, 'Failed to get autonomic status', err.message);
     }
   });
 

--- a/src/api/progression.js
+++ b/src/api/progression.js
@@ -1,6 +1,7 @@
 import express from 'express';
 import { logger } from '../../logger.js';
 import { progressionEngine } from '../../core/progression_engine.js';
+import { fail } from '../middleware/response.js';
 
 /**
  * Initialize progression system routes
@@ -17,7 +18,7 @@ export function initProgressionRoutes(broadcastPhaseChange = null) {
       res.json(status);
     } catch (err) {
       logger.error('Failed to get progression status', { error: err.message });
-      res.status(500).json({ error: 'Failed to get progression status' });
+      return fail(res, 500, 'Failed to get progression status', err.message);
     }
   });
 
@@ -30,7 +31,7 @@ export function initProgressionRoutes(broadcastPhaseChange = null) {
       res.json(phaseInfo);
     } catch (err) {
       logger.error('Failed to get phase info', { error: err.message });
-      res.status(500).json({ error: 'Failed to get phase info' });
+      return fail(res, 500, 'Failed to get phase info', err.message);
     }
   });
 
@@ -42,7 +43,7 @@ export function initProgressionRoutes(broadcastPhaseChange = null) {
       const { phase } = req.body;
 
       if (typeof phase !== 'number' || phase < 1 || phase > 6) {
-        return res.status(400).json({ error: 'Phase must be a number between 1 and 6' });
+        return fail(res, 400, 'Phase must be a number between 1 and 6');
       }
 
       await progressionEngine.setPhase(phase);
@@ -61,7 +62,7 @@ export function initProgressionRoutes(broadcastPhaseChange = null) {
       });
     } catch (err) {
       logger.error('Failed to set phase', { error: err.message });
-      res.status(500).json({ error: 'Failed to set phase' });
+      return fail(res, 500, 'Failed to set phase', err.message);
     }
   });
 
@@ -73,7 +74,7 @@ export function initProgressionRoutes(broadcastPhaseChange = null) {
       const metrics = req.body;
 
       if (!metrics || typeof metrics !== 'object') {
-        return res.status(400).json({ error: 'Invalid metrics object' });
+        return fail(res, 400, 'Invalid metrics object');
       }
 
       const phaseAdvanced = await progressionEngine.updateFederationState(metrics);
@@ -87,7 +88,7 @@ export function initProgressionRoutes(broadcastPhaseChange = null) {
       });
     } catch (err) {
       logger.error('Failed to update metrics', { error: err.message });
-      res.status(500).json({ error: 'Failed to update metrics' });
+      return fail(res, 500, 'Failed to update metrics', err.message);
     }
   });
 
@@ -104,7 +105,7 @@ export function initProgressionRoutes(broadcastPhaseChange = null) {
       } else if (value !== undefined) {
         progressionEngine.updateMetric(name, value);
       } else {
-        return res.status(400).json({ error: 'Must provide either value or increment' });
+        return fail(res, 400, 'Must provide either value or increment');
       }
 
       logger.info('Metric updated', { name, value, increment });
@@ -116,7 +117,7 @@ export function initProgressionRoutes(broadcastPhaseChange = null) {
       });
     } catch (err) {
       logger.error('Failed to update metric', { error: err.message, metric: req.params.name });
-      res.status(500).json({ error: 'Failed to update metric' });
+      return fail(res, 500, 'Failed to update metric', err.message);
     }
   });
 
@@ -135,7 +136,7 @@ export function initProgressionRoutes(broadcastPhaseChange = null) {
       });
     } catch (err) {
       logger.error('Failed to reset progression', { error: err.message });
-      res.status(500).json({ error: 'Failed to reset progression' });
+      return fail(res, 500, 'Failed to reset progression', err.message);
     }
   });
 
@@ -154,7 +155,7 @@ export function initProgressionRoutes(broadcastPhaseChange = null) {
       });
     } catch (err) {
       logger.error('Failed to get recommended tasks', { error: err.message });
-      res.status(500).json({ error: 'Failed to get recommended tasks' });
+      return fail(res, 500, 'Failed to get recommended tasks', err.message);
     }
   });
 

--- a/src/api/serverControl.js
+++ b/src/api/serverControl.js
@@ -1,5 +1,6 @@
 import express from 'express';
 import { authenticate, requirePermission } from '../../middleware/auth.js';
+import { fail } from '../middleware/response.js';
 
 export function initServerControlRoutes(serverControls) {
     const router = express.Router();
@@ -23,7 +24,7 @@ export function initServerControlRoutes(serverControls) {
                 if (restartServer) restartServer();
             }, 1000);
         } catch (err) {
-            res.status(500).json({ error: err.message });
+            return fail(res, 500, err.message);
         }
     });
 
@@ -34,7 +35,7 @@ export function initServerControlRoutes(serverControls) {
                 if (stopServer) stopServer();
             }, 1000);
         } catch (err) {
-            res.status(500).json({ error: err.message });
+            return fail(res, 500, err.message);
         }
     });
 

--- a/src/config/limits.js
+++ b/src/config/limits.js
@@ -1,0 +1,55 @@
+/**
+ * Centralised runtime limits and tunables.
+ *
+ * Every value is read from an environment variable with a sensible
+ * default so operators can tune without code changes. Callers should
+ * import from here rather than hardcoding numbers in individual files.
+ */
+
+function intEnv(name, fallback) {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function stringEnv(name, fallback) {
+  const raw = process.env[name];
+  return raw && raw.trim() ? raw.trim() : fallback;
+}
+
+export const AUTH_LIMITS = {
+  JWT_EXPIRES_IN: stringEnv('JWT_EXPIRES_IN', '1h'),
+  BCRYPT_SALT_ROUNDS: intEnv('BCRYPT_SALT_ROUNDS', 12),
+  REFRESH_TOKEN_TTL_MS: intEnv('REFRESH_TOKEN_TTL_MS', 7 * 24 * 60 * 60 * 1000), // 7 days
+  BLACKLIST_TTL_SEC: intEnv('JWT_BLACKLIST_TTL_SEC', 60 * 60), // 1 hour, matches default JWT TTL
+};
+
+export const RATE_LIMITS = {
+  API_WINDOW_MS: intEnv('RATE_LIMIT_WINDOW_MS', 15 * 60 * 1000),
+  API_MAX: intEnv('RATE_LIMIT_MAX', 100),
+  AUTH_WINDOW_MS: intEnv('AUTH_RATE_WINDOW_MS', 15 * 60 * 1000),
+  AUTH_MAX: intEnv('AUTH_RATE_MAX', 5),
+  BOT_CREATION_WINDOW_MS: intEnv('BOT_CREATION_WINDOW_MS', 60 * 60 * 1000),
+  BOT_CREATION_MAX: intEnv('BOT_CREATION_MAX', 10),
+  BOT_SPAWN_WINDOW_MS: intEnv('BOT_SPAWN_WINDOW_MS', 60 * 1000),
+  BOT_SPAWN_MAX: intEnv('BOT_SPAWN_MAX', 10),
+  BOT_SPAWN_ALL_WINDOW_MS: intEnv('BOT_SPAWN_ALL_WINDOW_MS', 5 * 60 * 1000),
+  BOT_SPAWN_ALL_MAX: intEnv('BOT_SPAWN_ALL_MAX', 2),
+};
+
+export const MINEFLAYER_LIMITS = {
+  PATHFINDING_TIMEOUT_MS: intEnv('MF_PATHFINDING_TIMEOUT_MS', 30_000),
+  MINING_TIMEOUT_MS: intEnv('MF_MINING_TIMEOUT_MS', 30_000),
+  MOVEMENT_TIMEOUT_MS: intEnv('MF_MOVEMENT_TIMEOUT_MS', 60_000),
+  INVENTORY_TIMEOUT_MS: intEnv('MF_INVENTORY_TIMEOUT_MS', 5_000),
+  CONNECTION_TIMEOUT_MS: intEnv('MF_CONNECTION_TIMEOUT_MS', 30_000),
+  RECONNECT_DELAY_MS: intEnv('MF_RECONNECT_DELAY_MS', 5_000),
+  MAX_RECONNECT_ATTEMPTS: intEnv('MF_MAX_RECONNECT_ATTEMPTS', 3),
+};
+
+export const HTTP_LIMITS = {
+  BODY_LIMIT: stringEnv('HTTP_BODY_LIMIT', '1mb'),
+};
+
+export default { AUTH_LIMITS, RATE_LIMITS, MINEFLAYER_LIMITS, HTTP_LIMITS };

--- a/src/config/mineflayer.js
+++ b/src/config/mineflayer.js
@@ -5,6 +5,8 @@
  * Can be overridden via environment variables.
  */
 
+import { MINEFLAYER_LIMITS } from './limits.js';
+
 export const mineflayerConfig = {
   // Server connection
   host: process.env.MINECRAFT_HOST || 'localhost',
@@ -20,36 +22,36 @@ export const mineflayerConfig = {
 
   // Pathfinding
   pathfinding: {
-    timeout: 30000, // 30 seconds
+    timeout: MINEFLAYER_LIMITS.PATHFINDING_TIMEOUT_MS,
     range: 1, // Stop within 1 block of target
     maxDistance: 128, // Don't search more than 128 blocks away
   },
 
   // Mining
   mining: {
-    timeout: 30000, // 30 seconds per block
+    timeout: MINEFLAYER_LIMITS.MINING_TIMEOUT_MS,
     equipTool: true, // Auto-select best tool
     maxDistance: 32, // Search radius for blocks
   },
 
   // Movement
   movement: {
-    timeout: 60000, // 60 seconds
+    timeout: MINEFLAYER_LIMITS.MOVEMENT_TIMEOUT_MS,
     range: 1, // Stop within 1 block
   },
 
   // Inventory
   inventory: {
     maxSlots: 36,
-    timeout: 5000,
+    timeout: MINEFLAYER_LIMITS.INVENTORY_TIMEOUT_MS,
   },
 
   // Timeouts and limits
   limits: {
     maxBots: 50, // Maximum concurrent bots
-    connectionTimeout: 30000, // 30 seconds to connect
-    reconnectDelay: 5000, // 5 seconds between reconnects
-    maxReconnectAttempts: 3,
+    connectionTimeout: MINEFLAYER_LIMITS.CONNECTION_TIMEOUT_MS,
+    reconnectDelay: MINEFLAYER_LIMITS.RECONNECT_DELAY_MS,
+    maxReconnectAttempts: MINEFLAYER_LIMITS.MAX_RECONNECT_ATTEMPTS,
   },
 
   // Events and logging

--- a/src/config/server.js
+++ b/src/config/server.js
@@ -3,6 +3,7 @@ import { createServer } from 'http';
 import { Server } from 'socket.io';
 import cors from 'cors';
 import compression from 'compression';
+import { HTTP_LIMITS } from './limits.js';
 
 /**
  * Creates and configures the Express app, HTTP server, and Socket.IO server
@@ -74,7 +75,7 @@ export function createAppServer() {
   );
 
   // Parse JSON bodies with an explicit size cap to mitigate large-payload DoS.
-  const bodyLimit = process.env.HTTP_BODY_LIMIT || '1mb';
+  const bodyLimit = HTTP_LIMITS.BODY_LIMIT;
   app.use(express.json({ limit: bodyLimit }));
   app.use(express.urlencoded({ extended: true, limit: bodyLimit }));
 

--- a/src/middleware/rateLimiter.js
+++ b/src/middleware/rateLimiter.js
@@ -1,13 +1,14 @@
 import rateLimit from 'express-rate-limit';
 import { ipKeyGenerator } from 'express-rate-limit';
+import { RATE_LIMITS } from '../config/limits.js';
 
 /**
- * General API rate limiter (100 requests per 15 minutes)
+ * General API rate limiter
  * Applied to all /api/ routes
  */
 export const apiLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 100,
+  windowMs: RATE_LIMITS.API_WINDOW_MS,
+  max: RATE_LIMITS.API_MAX,
   message: 'Too many requests from this IP, please try again later',
   standardHeaders: true,
   legacyHeaders: false,
@@ -18,13 +19,12 @@ export const apiLimiter = rateLimit({
 });
 
 /**
- * Strict auth rate limiter (5 login attempts per 15 minutes)
- * Applied to /api/auth/login route
- * Only counts failed login attempts
+ * Strict auth rate limiter
+ * Applied to /api/auth/login route. Only counts failed login attempts.
  */
 export const authLimiter = rateLimit({
-  windowMs: 15 * 60 * 1000,
-  max: 5,
+  windowMs: RATE_LIMITS.AUTH_WINDOW_MS,
+  max: RATE_LIMITS.AUTH_MAX,
   skipSuccessfulRequests: true,
   message: 'Too many login attempts, please try again later',
   standardHeaders: true,
@@ -32,12 +32,12 @@ export const authLimiter = rateLimit({
 });
 
 /**
- * Strict bot creation limiter (10 per hour)
+ * Strict bot creation limiter
  * Applied to POST /api/bots route
  */
 export const botCreationLimiter = rateLimit({
-  windowMs: 60 * 60 * 1000,
-  max: 10,
+  windowMs: RATE_LIMITS.BOT_CREATION_WINDOW_MS,
+  max: RATE_LIMITS.BOT_CREATION_MAX,
   message: 'Bot creation limit reached, please try again later',
   standardHeaders: true,
   legacyHeaders: false,
@@ -45,11 +45,10 @@ export const botCreationLimiter = rateLimit({
 
 /**
  * Spawn limiter - throttles bot spawns per user to prevent floods
- * Default: 10 spawns per minute per authenticated user (falls back to IP)
  */
 export const botSpawnLimiter = rateLimit({
-  windowMs: 60 * 1000,
-  max: 10,
+  windowMs: RATE_LIMITS.BOT_SPAWN_WINDOW_MS,
+  max: RATE_LIMITS.BOT_SPAWN_MAX,
   message: 'Spawn rate limit reached, please slow down',
   standardHeaders: true,
   legacyHeaders: false,
@@ -58,11 +57,10 @@ export const botSpawnLimiter = rateLimit({
 
 /**
  * Spawn-all limiter - restricts mass spawns server-wide
- * Default: 2 spawn-all requests per 5 minutes per user
  */
 export const botSpawnAllLimiter = rateLimit({
-  windowMs: 5 * 60 * 1000,
-  max: 2,
+  windowMs: RATE_LIMITS.BOT_SPAWN_ALL_WINDOW_MS,
+  max: RATE_LIMITS.BOT_SPAWN_ALL_MAX,
   message: 'Spawn-all rate limit reached, try again later',
   standardHeaders: true,
   legacyHeaders: false,

--- a/src/services/state.js
+++ b/src/services/state.js
@@ -7,6 +7,13 @@ export class SystemStateManager {
   constructor(io) {
     this.io = io;
     this.state = { ...DEFAULT_SYSTEM_STATE };
+    // Coalesce bursts of recompute requests into a single emit per tick.
+    // Many telemetry events can fire a recompute in the same microtask
+    // window; without this, we'd emit N `stats:update` events carrying
+    // essentially the same payload and in an order that depends on
+    // scheduler quirks. The flag serializes those into one.
+    this._recomputePending = false;
+    this._recomputeLastEngine = null;
   }
 
   /**
@@ -30,9 +37,22 @@ export class SystemStateManager {
   }
 
   /**
-   * Recompute system statistics
+   * Recompute system statistics. Coalesces bursts via `queueMicrotask` so
+   * several back-to-back recompute triggers (common during telemetry
+   * fan-in) produce at most one `stats:update` emit per tick, against the
+   * most recently supplied engine snapshot.
    */
   recomputeSystemStats(npcEngine) {
+    this._recomputeLastEngine = npcEngine ?? this._recomputeLastEngine;
+    if (this._recomputePending) return;
+    this._recomputePending = true;
+    queueMicrotask(() => {
+      this._recomputePending = false;
+      this._doRecompute(this._recomputeLastEngine);
+    });
+  }
+
+  _doRecompute(npcEngine) {
     const nodes = Array.isArray(this.state.nodes) ? this.state.nodes : [];
     const healthyNodes = nodes.filter((node) => node && node.status === 'healthy');
 


### PR DESCRIPTION
## Summary

Closes the three items marked "Deferred" in `docs/CODEBASE_REVIEW.md`. Depends on #85 — base of this PR is `claude/review-everything-yDkxi`; it'll auto-retarget to `main` when #85 merges.

## What's in here

### 1. `src/config/limits.js` — centralised runtime tunables
Every previously hardcoded timeout, TTL, rate-limit window, and bcrypt cost is now read from an env var with a sensible default, exposed through one module:

- **`AUTH_LIMITS`**: `JWT_EXPIRES_IN`, `BCRYPT_SALT_ROUNDS`, `REFRESH_TOKEN_TTL_MS`, `BLACKLIST_TTL_SEC`
- **`RATE_LIMITS`**: API / auth / bot-creation / bot-spawn / bot-spawn-all windows and maxes
- **`MINEFLAYER_LIMITS`**: pathfinding / mining / movement / inventory / connection / reconnect timeouts + max reconnect attempts
- **`HTTP_LIMITS`**: body cap

Wired into `middleware/auth.js`, `src/middleware/rateLimiter.js`, `src/config/mineflayer.js`, and `src/config/server.js`. No behaviour change at default values.

### 2. `src/services/state.js` — coalesced recompute
`recomputeSystemStats()` now defers the actual compute + emit to a `queueMicrotask` and drops any redundant triggers that arrive before it runs. Telemetry bursts no longer fan out into N `stats:update` emits in scheduler-dependent order — one tick, one emit, latest engine snapshot.

### 3. Response envelope — non-breaking widening
`fail()` applied across the remaining route files so every error now carries `success: false` plus `error` / `message`:

- `src/api/health.js`
- `src/api/progression.js`
- `src/api/autonomy.js`
- `src/api/serverControl.js`
- `routes/action.js`
- `routes/minecraft_status.js`
- `routes/llm.js`

**Success shapes intentionally unchanged** on endpoints that return raw data structures (metrics, status, logs) — dashboard clients read those by field name and a sudden envelope wrapper would break them. That's a separate, client-coordinated change.

## Test plan

- [ ] `npm install && npm test` (existing suites should stay green)
- [ ] Hit one error path on `/api/health`, `/api/progression`, `/api/autonomy/goal`, `/api/llm/command` and confirm the body contains `success: false`
- [ ] Set one of the new env vars (e.g. `BCRYPT_SALT_ROUNDS=14`, `MF_PATHFINDING_TIMEOUT_MS=45000`) and verify it takes effect
- [ ] Smoke-test that a batch of progression metric updates produces at most one `stats:update` emit per tick

https://claude.ai/code/session_011PPrfv51tDnov8p9LVaaLi